### PR TITLE
Check if entity is in any group before checking specific group

### DIFF
--- a/src/com/artemis/managers/GroupManager.java
+++ b/src/com/artemis/managers/GroupManager.java
@@ -124,11 +124,13 @@ public class GroupManager extends Manager {
 	public boolean isInGroup(Entity e, String group) {
 		if(group != null) {
 			Bag<String> bag = groupsByEntity.get(e);
-			Object[] groups = bag.getData();
-			for(int i = 0, s = bag.size(); s > i; i++) {
-				String g = (String)groups[i];
-				if(group.equals(g)) {
-					return true;
+			if (bag != null) {
+				Object[] groups = bag.getData();
+				for(int i = 0, s = bag.size(); s > i; i++) {
+					String g = (String)groups[i];
+					if(group.equals(g)) {
+						return true;
+					}
 				}
 			}
 		}


### PR DESCRIPTION
Would throw a NullPointerException at bag.getData() when entity is in no group.
Removes some overhead in comparison to calling isInAnyGroup() before every call to isInGroup()
as the bag is already fetched.

(ignore the lot of commits, had some problem with tab/space settings in my ide, had to keep reverting -.-')
