### PR TITLE
GroupManager: avoid duplicate entities in groups and leaking entity objects.

### DIFF
--- a/artemis/src/main/java/com/artemis/managers/GroupManager.java
+++ b/artemis/src/main/java/com/artemis/managers/GroupManager.java
@@ -56,14 +56,14 @@ public class GroupManager extends Manager {
 			entities = new Bag<Entity>();
 			entitiesByGroup.put(group, entities);
 		}
-		entities.add(e);
+		if (!entities.contains(e)) entities.add(e);
 		
 		Bag<String> groups = groupsByEntity.get(e);
 		if(groups == null) {
 			groups = new Bag<String>();
 			groupsByEntity.put(e, groups);
 		}
-		groups.add(group);
+		if (!groups.contains(group)) groups.add(group);
 	}
 	
 	/**
@@ -83,6 +83,7 @@ public class GroupManager extends Manager {
 		Bag<String> groups = groupsByEntity.get(e);
 		if(groups != null) {
 			groups.remove(group);
+			if (groups.size() == 0) groupsByEntity.remove(e);
 		}
 	}
 
@@ -94,15 +95,14 @@ public class GroupManager extends Manager {
 	 */
 	public void removeFromAllGroups(Entity e) {
 		Bag<String> groups = groupsByEntity.get(e);
-		if(groups != null) {
-			for(int i = 0, s = groups.size(); s > i; i++) {
-				Bag<Entity> entities = entitiesByGroup.get(groups.get(i));
-				if(entities != null) {
-					entities.remove(e);
-				}
+		if(groups == null) return;
+		for(int i = 0, s = groups.size(); s > i; i++) {
+			Bag<Entity> entities = entitiesByGroup.get(groups.get(i));
+			if(entities != null) {
+				entities.remove(e);
 			}
-			groups.clear();
 		}
+		groupsByEntity.remove(e);
 	}
 	
 	/**


### PR DESCRIPTION
When adding an entity to a group we should check to see if it’s already
there.

When removing entities from a group and that group contains no more
entities then we should delete the entity/group pair from
groupsByEntity hash so that garbage collector can destroy.

Finally, removeFromAllGroups(e) was clearing the group within the
iteration of the group!? Got rid of it in favor of removing the entire
group from the groupsByEntity has once we’re done with that job.

This is untested as of pull request and submitted at very least as a
detailed notice of these flaws. Also there may be a better solution
than I’ve posted here and am very open to alternatives and feedback.

JunkDog will you please run a test? I’m not setup for testing at the
moment but want to learn how to be. Thanks ahead.
