### PR TITLE
updated World.deleteEntity to always try to remove the entity from the "added" bag.

### DIFF
--- a/artemis/src/main/java/com/artemis/World.java
+++ b/artemis/src/main/java/com/artemis/World.java
@@ -265,7 +265,9 @@ public class World {
 		if (!deleted.contains(e)) {
 			deleted.add(e);
 			check(e, deletedPerformer);
-		} else {
+		}
+		
+		if(added.contains(e)) {
 			added.remove(e);
 		}
 	}


### PR DESCRIPTION
This fixes a lot of NPEs when an entity is added and deleted very quickly.

I am in the process of taking the old SpaceshipWarrior artemis project and "modernizing" it with a full maven libgdx project using artemis-odb. I was getting lots of NullPointerExceptions  when the bullets were deleted very quickly (when directly on top of a ship and firing).

I tracked it down to this little change. Please let me know what you think.
