### PR TITLE
Fix issue #91: EntitySystem is not interested in inactive entities.

### DIFF
--- a/artemis/src/main/java/com/artemis/EntitySystem.java
+++ b/artemis/src/main/java/com/artemis/EntitySystem.java
@@ -197,11 +197,16 @@ public abstract class EntitySystem implements EntityObserver {
 		
 		boolean contains = e.getSystemBits().get(systemIndex);
 		boolean interested = true; // possibly interested, let's try to prove it wrong.
-		
+
+		// If the entity is inactive, then we aren't interested
+		if (!e.isActive()) {
+			interested = false;
+		}
+
 		BitSet componentBits = e.getComponentBits();
 
 		// Check if the entity possesses ALL of the components defined in the aspect.
-		if(!allSet.isEmpty()) {
+		if(!allSet.isEmpty() && interested) {
 			for (int i = allSet.nextSetBit(0); i >= 0; i = allSet.nextSetBit(i+1)) {
 				if(!componentBits.get(i)) {
 					interested = false;

--- a/artemis/src/test/java/com/artemis/EntitySystemTest.java
+++ b/artemis/src/test/java/com/artemis/EntitySystemTest.java
@@ -1,0 +1,64 @@
+package com.artemis;
+;
+import com.artemis.utils.ImmutableBag;
+import org.junit.Test;
+
+import java.util.NoSuchElementException;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+/**
+ * Created by obartley on 6/9/14.
+ */
+public class EntitySystemTest {
+
+	@Test(expected = NoSuchElementException.class)
+	public void test_process_one_inactive() {
+		World w = new World();
+
+		w.setSystem(new IteratorTestSystem(0));
+		w.initialize();
+
+		Entity e = w.createEntity();
+		e.addComponent(new C());
+		e.changedInWorld();
+
+		w.process();
+	}
+
+	public void test_process_one_active() {
+		World w = new World();
+
+		w.setSystem(new IteratorTestSystem(1));
+		w.initialize();
+
+		Entity e = w.createEntity();
+		e.addComponent(new C());
+		e.addToWorld();
+		e.changedInWorld();
+
+		w.process();
+	}
+
+	public static class C extends Component {}
+
+	public static class IteratorTestSystem extends EntitySystem {
+		public int expectedSize;
+		public IteratorTestSystem(int expectedSize) {
+			super(Aspect.getAspectForAll(C.class));
+			this.expectedSize = expectedSize;
+		}
+
+		@Override
+		protected void processEntities(ImmutableBag<Entity> entities) {
+			assertEquals(expectedSize, entities.size());
+			entities.iterator().next();
+		}
+
+		@Override
+		protected boolean checkProcessing() {
+			return true;
+		}
+	}
+}


### PR DESCRIPTION
EntitySystem#check() was happily inserting inactive entities. I've included a unit test that exercises the change.
