### PR TITLE
Extend gwt reflection cache with method annotations.

### DIFF
--- a/artemis-gwt/src/main/java/com/artemis/backends/gwt/emu/com/artemis/utils/reflect/Method.java
+++ b/artemis-gwt/src/main/java/com/artemis/backends/gwt/emu/com/artemis/utils/reflect/Method.java
@@ -18,6 +18,7 @@ package com.artemis.utils.reflect;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Modifier;
+import java.util.Arrays;
 
 import com.artemis.gwtref.client.Parameter;
 import com.artemis.utils.reflect.ReflectionException;
@@ -118,5 +119,10 @@ public final class Method {
 			throw new ReflectionException("Illegal argument(s) supplied to method: " + getName(), e);
 		}
 	}
+
+    @SuppressWarnings("rawtypes")
+       public boolean hasAnnotation(Class annotationClass) {
+   	    return Arrays.asList(method.getAnnotationClasses()).contains(annotationClass.getName());
+       }
 
 }

--- a/artemis-gwt/src/main/java/com/artemis/gwtref/client/Constructor.java
+++ b/artemis-gwt/src/main/java/com/artemis/gwtref/client/Constructor.java
@@ -21,9 +21,9 @@ package com.artemis.gwtref.client;
 public class Constructor extends Method {
 	Constructor (String name, Class enclosingType, Class returnType, Parameter[] parameters, boolean isAbstract, boolean isFinal,
 		boolean isStatic, boolean isDefaultAccess, boolean isPrivate, boolean isProtected, boolean isPublic, boolean isNative,
-		boolean isVarArgs, boolean isMethod, boolean isConstructor, int methodId) {
+		boolean isVarArgs, boolean isMethod, boolean isConstructor, int methodId, String[] annotationClasses) {
 		super(name, enclosingType, returnType, parameters, isAbstract, isFinal, isStatic, isDefaultAccess, isPrivate, isProtected,
-			isPublic, isNative, isVarArgs, isMethod, isConstructor, methodId);
+			isPublic, isNative, isVarArgs, isMethod, isConstructor, methodId, annotationClasses);
 	}
 
 	/** @return a new instance of the enclosing type of this constructor. */

--- a/artemis-gwt/src/main/java/com/artemis/gwtref/client/Method.java
+++ b/artemis-gwt/src/main/java/com/artemis/gwtref/client/Method.java
@@ -38,10 +38,11 @@ public class Method {
 	final boolean isConstructor;
 	final Parameter[] parameters;
 	final int methodId;
+    final String[] annotationClasses;
 
 	public Method (String name, Class enclosingType, Class returnType, Parameter[] parameters, boolean isAbstract,
 		boolean isFinal, boolean isStatic, boolean isDefaultAccess, boolean isPrivate, boolean isProtected, boolean isPublic,
-		boolean isNative, boolean isVarArgs, boolean isMethod, boolean isConstructor, int methodId) {
+		boolean isNative, boolean isVarArgs, boolean isMethod, boolean isConstructor, int methodId, String[] annotationClasses) {
 		this.name = name;
 		this.enclosingType = enclosingType;
 		this.parameters = parameters != null ? parameters : EMPTY_PARAMS;
@@ -58,7 +59,12 @@ public class Method {
 		this.isMethod = isMethod;
 		this.isConstructor = isConstructor;
 		this.methodId = methodId;
-	}
+        this.annotationClasses = annotationClasses;
+      	}
+
+      	public String[] getAnnotationClasses() {
+      		return annotationClasses;
+      	}
 
 	/** @return the {@link Class} of the enclosing type. */
 	public Class getEnclosingType () {

--- a/artemis-gwt/src/main/java/com/artemis/gwtref/gen/ReflectionCacheSourceCreator.java
+++ b/artemis-gwt/src/main/java/com/artemis/gwtref/gen/ReflectionCacheSourceCreator.java
@@ -69,6 +69,7 @@ public class ReflectionCacheSourceCreator {
 		boolean isMethod;
 		String name;
 		boolean unused;
+        String annotationClasses;
 	}
 
 	public ReflectionCacheSourceCreator (TreeLogger logger, GeneratorContext context, JClassType type) {
@@ -589,10 +590,13 @@ public class ReflectionCacheSourceCreator {
 					stub.isAbstract = m.isMethod().isAbstract();
 					stub.isNative = m.isMethod().isAbstract();
 					stub.isFinal = m.isMethod().isFinal();
+
 				} else {
 					stub.isConstructor = true;
 					stub.returnType = stub.enclosingType;
 				}
+
+                stub.annotationClasses = getClassAnnotationsAsString(m);
 				stub.jnsi = "";
 				stub.methodId = nextId();
 				stub.name = m.getName();
@@ -615,13 +619,27 @@ public class ReflectionCacheSourceCreator {
 
 				pb(stub.isAbstract + ", " + stub.isFinal + ", " + stub.isStatic + ", " + m.isDefaultAccess() + ", " + m.isPrivate()
 					+ ", " + m.isProtected() + ", " + m.isPublic() + ", " + stub.isNative + ", " + m.isVarArgs() + ", "
-					+ stub.isMethod + ", " + stub.isConstructor + ", " + stub.methodId + "),");
+					+ stub.isMethod + ", " + stub.isConstructor + ", " + stub.methodId + ", " + stub.annotationClasses + "),");
 			}
 			pb("};");
 		}
 	}
 
-	private String getElementTypes (JField f) {
+    private String getClassAnnotationsAsString(JAbstractMethod m) {
+        Annotation[] annotations = m.getAnnotations();
+        StringBuilder annotationClasses = new StringBuilder("new String[]{");
+
+        for (int i = 0; i < annotations.length; i++) {
+                 annotationClasses.append("\"").append(annotations[i].annotationType().getName()).append("\"");
+                   if(i < annotations.length-1) {
+                       annotationClasses.append(",");
+                   }
+}
+        annotationClasses.append("}");
+        return annotationClasses.toString();
+    }
+
+    private String getElementTypes (JField f) {
 		StringBuilder b = new StringBuilder();
 		JParameterizedType params = f.getType().isParameterized();
 		if (params != null) {

--- a/artemis/src/main/java/com/artemis/utils/reflect/Method.java
+++ b/artemis/src/main/java/com/artemis/utils/reflect/Method.java
@@ -115,4 +115,8 @@ public final class Method {
 		}
 	}
 
+    @SuppressWarnings({ "rawtypes", "unchecked" })
+    public boolean hasAnnotation(Class annotationClass) {
+    	return method.getAnnotation(annotationClass) != null;
+    }
 }


### PR DESCRIPTION
Extends the GWT reflection cache to support method annotations. Similar change to the one we made to support annotation on classes.

Added this for @Subscribe event annotation on Systems and Manager methods. I rather not fork the whole reflection cache for artemis-contrib.

NS2D compiles and runs fine with this change, but to be honest have only done superficial testing. Let me know if you want something more solid first.
