### PR TITLE
Improve salespitch in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,15 +94,15 @@ There's a google group at https://groups.google.com/forum/#!forum/artemis-odb - 
 </dependency>
 ```
 
+See [weave automation](https://github.com/junkdog/artemis-odb/wiki/Weave-Automation) and [module overview](https://github.com/junkdog/artemis-odb/wiki/Module-Overview)
+
 #### Gradle
 ```groovy
   dependencies { compile "net.onedaybeard.artemis:artemis-odb:0.7.0" }
 ```
 
-See [weave automation](https://github.com/junkdog/artemis-odb/wiki/Weave-Automation) and [module overview](https://github.com/junkdog/artemis-odb/wiki/Module-Overview)
-
 #### Manual Download
 
- - **Main library:** http://repo1.maven.org/maven2/net/onedaybeard/artemis/artemis-odb/0.7.0/
- - **Command-line tool[cli]:** http://repo1.maven.org/maven2/net/onedaybeard/artemis/artemis-odb-cli/0.7.0/
+ - [Main library](http://repo1.maven.org/maven2/net/onedaybeard/artemis/artemis-odb/0.7.0/) 
+ - [Command-line tool](http://repo1.maven.org/maven2/net/onedaybeard/artemis/artemis-odb-cli/0.7.0/)
 


### PR DESCRIPTION
Readme was a bit underselling.
- Get rid of the 'default private fork' intro paragraph, claim more of an identity.
- Refactor the readme for people ECS shopping and no familiarity with ODB.
- Strip out advanced topics of no interest to new users, now better covered by the wiki (modules, advanced weaving maven instructions).
- Add benchmark section. (Picked 16k as a typical usecase for people that need a high performance ECS)
- Order topics by relevance.
- Move CDM image down, it's giant! (I think a cutout would suffice honestly).

Preview here: https://github.com/junkdog/artemis-odb/blob/document-improved-salespitch/README.md
