### PR TITLE
Better fluent api for aspects

### DIFF
--- a/artemis-cli/src/main/java/com/artemis/cli/EclipseProcessorCommand.java
+++ b/artemis-cli/src/main/java/com/artemis/cli/EclipseProcessorCommand.java
@@ -22,7 +22,6 @@ import com.artemis.cli.converter.EclipseProjectFolder;
 import com.artemis.cli.converter.FolderConverter;
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
-import com.beust.jcommander.Strings;
 
 @Parameters(
 	commandDescription="Configures EntityFactory Annotation Processor with Eclipse project")

--- a/artemis-processor/src/main/java/com/artemis/FactoryModel.java
+++ b/artemis-processor/src/main/java/com/artemis/FactoryModel.java
@@ -25,8 +25,6 @@ import javax.lang.model.element.TypeElement;
 import javax.lang.model.element.VariableElement;
 import javax.lang.model.type.DeclaredType;
 import javax.lang.model.type.TypeMirror;
-import javax.lang.model.util.Elements;
-import javax.lang.model.util.Types;
 import javax.tools.Diagnostic.Kind;
 
 import com.artemis.annotations.Bind;

--- a/artemis-processor/src/test/java/com/artemis/component/Position.java
+++ b/artemis-processor/src/test/java/com/artemis/component/Position.java
@@ -1,7 +1,6 @@
 package com.artemis.component;
 
 import com.artemis.Component;
-import com.artemis.annotations.PackedWeaver;
 import com.artemis.util.Vec2f;
 
 public class Position extends Component

--- a/artemis-test/src/main/java/com/artemis/component/Position.java
+++ b/artemis-test/src/main/java/com/artemis/component/Position.java
@@ -1,7 +1,6 @@
 package com.artemis.component;
 
 import com.artemis.Component;
-import com.artemis.annotations.PackedWeaver;
 import com.artemis.util.Vec2f;
 
 public class Position extends Component

--- a/artemis-test/src/main/java/com/artemis/component/WorldStructWeavingBase.java
+++ b/artemis-test/src/main/java/com/artemis/component/WorldStructWeavingBase.java
@@ -80,7 +80,6 @@ public class WorldStructWeavingBase {
 		private ComponentMapper<StructComponentA> mapper;
 		int iteration = 0;
 		
-		@SuppressWarnings("unchecked")
 		public EntitySystemA() {
 			super(Aspect.all(StructComponentA.class));
 		}
@@ -114,7 +113,6 @@ public class WorldStructWeavingBase {
 		private ComponentMapper<Position> mapper;
 		int iteration = 0;
 		
-		@SuppressWarnings("unchecked")
 		public EntitySystemB() {
 			super(Aspect.all(Position.class));
 		}

--- a/artemis-test/src/main/java/com/artemis/factory/ShipNoMethods.java
+++ b/artemis-test/src/main/java/com/artemis/factory/ShipNoMethods.java
@@ -2,13 +2,8 @@ package com.artemis.factory;
 
 import com.artemis.EntityFactory;
 import com.artemis.annotations.Bind;
-import com.artemis.annotations.Sticky;
-import com.artemis.component.Asset;
 import com.artemis.component.Cullible;
-import com.artemis.component.Position;
-import com.artemis.component.Size;
 import com.artemis.component.Sprite;
-import com.artemis.component.Velocity;
 
 @Bind({Sprite.class, Cullible.class})
 public interface ShipNoMethods extends EntityFactory<ShipNoMethods> {

--- a/artemis-test/src/main/java/com/artemis/system/OptimizedSystemAdditional.java
+++ b/artemis-test/src/main/java/com/artemis/system/OptimizedSystemAdditional.java
@@ -7,7 +7,7 @@ import com.artemis.systems.EntityProcessingSystem;
 public class OptimizedSystemAdditional extends EntityProcessingSystem {
 
 	public OptimizedSystemAdditional() {
-		super(Aspect.all());
+		super(Aspect.empty());
 
 		setEnabled(true);
 		begin();

--- a/artemis-test/src/main/java/com/artemis/system/OptimizedSystemSafe.java
+++ b/artemis-test/src/main/java/com/artemis/system/OptimizedSystemSafe.java
@@ -1,6 +1,5 @@
 package com.artemis.system;
 
-import com.artemis.Aspect;
 import com.artemis.Entity;
 import com.artemis.annotations.PreserveProcessVisiblity;
 import com.artemis.systems.EntityProcessingSystem;

--- a/artemis-test/src/main/java/com/artemis/system/ProfiledSystem.java
+++ b/artemis-test/src/main/java/com/artemis/system/ProfiledSystem.java
@@ -10,7 +10,7 @@ import com.artemis.util.SimpleProfiler;
 @Profile(enabled=true, using=SimpleProfiler.class)
 public class ProfiledSystem extends EntityProcessingSystem {
 	public ProfiledSystem() {
-		super(Aspect.all());
+		super(Aspect.empty());
 	}
 
 	@Override

--- a/artemis-test/src/test/java/com/artemis/EntityFactoryTest.java
+++ b/artemis-test/src/test/java/com/artemis/EntityFactoryTest.java
@@ -12,7 +12,6 @@ import com.artemis.component.Cullible;
 import com.artemis.component.HitPoints;
 import com.artemis.component.Position;
 import com.artemis.factory.ExhibitA;
-import com.artemis.factory.Extended;
 
 @Wire
 public class EntityFactoryTest {

--- a/artemis-test/src/test/java/com/artemis/FactoryWireTest.java
+++ b/artemis-test/src/test/java/com/artemis/FactoryWireTest.java
@@ -2,7 +2,6 @@ package com.artemis;
 
 import static org.junit.Assert.*;
 
-import org.junit.Assert;
 import org.junit.Test;
 
 import com.artemis.annotations.Wire;

--- a/artemis-test/src/test/java/com/artemis/component/IntPackedWeavingTest.java
+++ b/artemis-test/src/test/java/com/artemis/component/IntPackedWeavingTest.java
@@ -1,7 +1,6 @@
 package com.artemis.component;
 
 import static java.lang.reflect.Modifier.PRIVATE;
-import static java.lang.reflect.Modifier.STATIC;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 

--- a/artemis-test/src/test/java/com/artemis/component/LongPackedWeavingTest.java
+++ b/artemis-test/src/test/java/com/artemis/component/LongPackedWeavingTest.java
@@ -1,15 +1,12 @@
 package com.artemis.component;
 
 import static java.lang.reflect.Modifier.PRIVATE;
-import static java.lang.reflect.Modifier.STATIC;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.nio.ByteBuffer;
-import java.nio.LongBuffer;
-
 import org.junit.Before;
 import org.junit.Test;
 

--- a/artemis-test/src/test/java/com/artemis/component/PooledResetTest.java
+++ b/artemis-test/src/test/java/com/artemis/component/PooledResetTest.java
@@ -5,7 +5,6 @@ import static org.junit.Assert.assertTrue;
 
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import com.artemis.Entity;

--- a/artemis-weaver/src/main/java/com/artemis/Weaver.java
+++ b/artemis-weaver/src/main/java/com/artemis/Weaver.java
@@ -8,8 +8,6 @@ import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.PrintWriter;
-import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;

--- a/artemis-weaver/src/main/java/com/artemis/weaver/ComponentAccessTransmuter.java
+++ b/artemis-weaver/src/main/java/com/artemis/weaver/ComponentAccessTransmuter.java
@@ -12,7 +12,6 @@ import org.objectweb.asm.tree.ClassNode;
 import com.artemis.ClassUtil;
 import com.artemis.Weaver;
 import com.artemis.meta.ClassMetadata;
-import com.artemis.meta.ClassMetadataUtil;
 import com.artemis.weaver.packed.ExternalFieldClassTransformer;
 
 /**

--- a/artemis-weaver/src/main/java/com/artemis/weaver/packed/PackedComponentWeaver.java
+++ b/artemis-weaver/src/main/java/com/artemis/weaver/packed/PackedComponentWeaver.java
@@ -9,7 +9,6 @@ import org.objectweb.asm.MethodVisitor;
 import org.objectweb.asm.Opcodes;
 
 import com.artemis.meta.ClassMetadata;
-import com.artemis.meta.ClassMetadata.WeaverType;
 import com.artemis.weaver.ConstructorInvocationVisitor;
 
 public class PackedComponentWeaver extends ClassVisitor implements Opcodes{

--- a/artemis-weaver/src/main/java/com/artemis/weaver/pooled/ResetMethodVisitor.java
+++ b/artemis-weaver/src/main/java/com/artemis/weaver/pooled/ResetMethodVisitor.java
@@ -7,7 +7,6 @@ import org.objectweb.asm.MethodVisitor;
 import org.objectweb.asm.Opcodes;
 
 import com.artemis.meta.ClassMetadata;
-import com.artemis.meta.ClassMetadataUtil;
 import com.artemis.meta.FieldDescriptor;
 
 public class ResetMethodVisitor extends MethodVisitor implements Opcodes {

--- a/artemis-weaver/src/test/java/com/artemis/ComponentTypeWeaverTest.java
+++ b/artemis-weaver/src/test/java/com/artemis/ComponentTypeWeaverTest.java
@@ -1,7 +1,6 @@
 package com.artemis;
 
 import static com.artemis.Transformer.transform;
-import static com.artemis.Weaver.scan;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;

--- a/artemis-weaver/src/test/java/com/artemis/system/PoorFellowSystem.java
+++ b/artemis-weaver/src/test/java/com/artemis/system/PoorFellowSystem.java
@@ -7,7 +7,7 @@ import com.artemis.systems.EntityProcessingSystem;
 public final class PoorFellowSystem extends EntityProcessingSystem {
 
 	public PoorFellowSystem(Aspect aspect) {
-		super(Aspect.all());
+		super(Aspect.empty());
 	}
 
 	@Override

--- a/artemis-weaver/src/test/java/com/artemis/system/SafeOptimizeSystem.java
+++ b/artemis-weaver/src/test/java/com/artemis/system/SafeOptimizeSystem.java
@@ -9,7 +9,7 @@ import com.artemis.systems.EntityProcessingSystem;
 public final class SafeOptimizeSystem extends EntityProcessingSystem {
 
 	public SafeOptimizeSystem(Aspect aspect) {
-		super(Aspect.all());
+		super(Aspect.empty());
 	}
 
 	@Override

--- a/artemis/src/main/java/com/artemis/Aspect.java
+++ b/artemis/src/main/java/com/artemis/Aspect.java
@@ -1,10 +1,10 @@
 package com.artemis;
 
+import java.util.Arrays;
 import java.util.BitSet;
 import java.util.Collection;
 
 import com.artemis.utils.Bag;
-
 
 /**
  * An Aspect is used by systems as a matcher against entities, to check if a
@@ -12,20 +12,25 @@ import com.artemis.utils.Bag;
  * <p>
  * Aspects define what sort of component types an entity must possess, or not
  * possess.
- * </p><p>
+ * </p>
+ * <p>
  * This creates an aspect where an entity must possess A and B and C:<br />
  * {@code Aspect.all(A.class, B.class, C.class)}
- * </p><p>
+ * </p>
+ * <p>
  * This creates an aspect where an entity must possess A and B and C, but must
  * not possess U or V.<br />
  * {@code Aspect.all(A.class, B.class, C.class).exclude(U.class, V.class)}
- * </p><p>
+ * </p>
+ * <p>
  * This creates an aspect where an entity must possess A and B and C, but must
  * not possess U or V, but must possess one of X or Y or Z.<br />
  * {@code Aspect.all(A.class, B.class, C.class).exclude(U.class, V.class).one(X.class, Y.class, Z.class)}
- * </p><p>
+ * </p>
+ * <p>
  * You can create and compose aspects in many ways:<br />
- * {@code Aspect.one(X.class, Y.class, Z.class).all(A.class, B.class, C.class).exclude(U.class, V.class)}<br />
+ * {@code Aspect.one(X.class, Y.class, Z.class).all(A.class, B.class, C.class).exclude(U.class, V.class)}
+ * <br />
  * is the same as:<br />
  * {@code Aspect.all(A.class, B.class, C.class).exclude(U.class, V.class).one(X.class, Y.class, Z.class)}
  * </p>
@@ -40,18 +45,17 @@ public class Aspect {
 	private BitSet exclusionSet;
 	/** Component bits of which the entity must possess at least one. */
 	private BitSet oneSet;
-	
+
 	private Aspect() {
 		this.allSet = new BitSet();
 		this.exclusionSet = new BitSet();
 		this.oneSet = new BitSet();
 	}
-	
+
 	/**
 	 * Get a BitSet containing bits of components the entity must all possess.
 	 *
-	 * @return
-	 *		the "all" BitSet
+	 * @return the "all" BitSet
 	 */
 	public BitSet getAllSet() {
 		return allSet;
@@ -60,8 +64,7 @@ public class Aspect {
 	/**
 	 * Get a BitSet containing bits of components the entity must not possess.
 	 *
-	 * @return
-	 *		the "exclusion" BitSet
+	 * @return the "exclusion" BitSet
 	 */
 	public BitSet getExclusionSet() {
 		return exclusionSet;
@@ -71,8 +74,7 @@ public class Aspect {
 	 * Get a BitSet containing bits of components of which the entity must
 	 * possess atleast one.
 	 *
-	 * @return
-	 *		the "one" BitSet
+	 * @return the "one" BitSet
 	 */
 	public BitSet getOneSet() {
 		return oneSet;
@@ -81,39 +83,42 @@ public class Aspect {
 	/**
 	 * Returns whether this Aspect would accept the given Entity.
 	 */
-	public boolean isInterested(Entity e){
+	public boolean isInterested(Entity e) {
 		return isInterested(e.getComponentBits());
 	}
-	
+
 	/**
 	 * Returns whether this Aspect would accept the given set.
 	 */
-	public boolean isInterested(BitSet componentBits){
-		// Check if the entity possesses ALL of the components defined in the aspect.
-		if(!allSet.isEmpty()) {
-			for (int i = allSet.nextSetBit(0); i >= 0; i = allSet.nextSetBit(i+1)) {
-				if(!componentBits.get(i)) {
+	public boolean isInterested(BitSet componentBits) {
+		// Check if the entity possesses ALL of the components defined in the
+		// aspect.
+		if (!allSet.isEmpty()) {
+			for (int i = allSet.nextSetBit(0); i >= 0; i = allSet
+					.nextSetBit(i + 1)) {
+				if (!componentBits.get(i)) {
 					return false;
 				}
 			}
 		}
-		
+
 		// If we are STILL interested,
-		// Check if the entity possesses ANY of the exclusion components, if it does then the system is not interested.
-		if(!exclusionSet.isEmpty() && exclusionSet.intersects(componentBits)) {
+		// Check if the entity possesses ANY of the exclusion components, if it
+		// does then the system is not interested.
+		if (!exclusionSet.isEmpty() && exclusionSet.intersects(componentBits)) {
 			return false;
 		}
 
 		// If we are STILL interested,
-		// Check if the entity possesses ANY of the components in the oneSet. If so, the system is interested.
-		if(!oneSet.isEmpty() && !oneSet.intersects(componentBits)) {
+		// Check if the entity possesses ANY of the components in the oneSet. If
+		// so, the system is interested.
+		if (!oneSet.isEmpty() && !oneSet.intersects(componentBits)) {
 			return false;
 		}
-		
+
 		return true;
 	}
-	
-	
+
 	/**
 	 * Returns an aspect where an entity must possess all of the specified
 	 * component types.
@@ -123,11 +128,24 @@ public class Aspect {
 	 *
 	 * @return an aspect that can be matched against entities
 	 */
-	public static Aspect.Builder all(Class<? extends Component>... types) {
-		return new Builder().all(types);
+	public static Aspect.Builder all(Class<? extends Component> type) {
+		return new Builder().all(type);
 	}
-	
-	
+
+	/**
+	 * Returns an aspect where an entity must possess all of the specified
+	 * component types.
+	 *
+	 * @param types
+	 * 			a required component type
+	 *
+	 * @return an aspect that can be matched against entities
+	 */
+	public static Aspect.Builder all(Class<? extends Component> type,
+			Class<? extends Component>... types) {
+		return new Builder().all(type, types);
+	}
+
 	/**
 	 * Returns an aspect where an entity must possess all of the specified
 	 * component types.
@@ -137,10 +155,27 @@ public class Aspect {
 	 *
 	 * @return an aspect that can be matched against entities
 	 */
-	public static Aspect.Builder all(Collection<Class<? extends Component>> types) {
+	public static Aspect.Builder all(
+			Collection<Class<? extends Component>> types) {
 		return new Builder().all(types);
 	}
-	
+
+	/**
+	 * Excludes all of the specified component types from the aspect.
+	 * <p>
+	 * A system will not be interested in an entity that possesses one of the
+	 * specified exclusion component types.
+	 * </p>
+	 *
+	 * @param types
+	 * 			component type to exclude
+	 *
+	 * @return an aspect that can be matched against entities
+	 */
+	public static Aspect.Builder exclude(Class<? extends Component> type) {
+		return new Builder().exclude(type);
+	}
+
 	/**
 	 * Excludes all of the specified component types from the aspect.
 	 * <p>
@@ -153,11 +188,11 @@ public class Aspect {
 	 *
 	 * @return an aspect that can be matched against entities
 	 */
-	public static Aspect.Builder exclude(Class<? extends Component>... types) {
-		return new Builder().exclude(types);
+	public static Aspect.Builder exclude(Class<? extends Component> type,
+			Class<? extends Component>... types) {
+		return new Builder().exclude(type, types);
 	}
-	
-	
+
 	/**
 	 * Excludes all of the specified component types from the aspect.
 	 * <p>
@@ -170,10 +205,11 @@ public class Aspect {
 	 *
 	 * @return an aspect that can be matched against entities
 	 */
-	public static Aspect.Builder exclude(Collection<Class<? extends Component>> types) {
+	public static Aspect.Builder exclude(
+			Collection<Class<? extends Component>> types) {
 		return new Builder().exclude(types);
 	}
-	
+
 	/**
 	 * Returns an aspect where an entity must possess one of the specified
 	 * component types.
@@ -183,10 +219,10 @@ public class Aspect {
 	 *
 	 * @return an aspect that can be matched against entities
 	 */
-	public static Aspect.Builder one(Class<? extends Component>... types) {
-		return new Builder().one(types);
+	public static Aspect.Builder one(Class<? extends Component> type) {
+		return new Builder().one(type);
 	}
-	
+
 	/**
 	 * Returns an aspect where an entity must possess one of the specified
 	 * component types.
@@ -196,10 +232,25 @@ public class Aspect {
 	 *
 	 * @return an aspect that can be matched against entities
 	 */
-	public static Aspect.Builder one(Collection<Class<? extends Component>> types) {
+	public static Aspect.Builder one(Class<? extends Component> type,
+			Class<? extends Component>... types) {
+		return new Builder().one(type, types);
+	}
+
+	/**
+	 * Returns an aspect where an entity must possess one of the specified
+	 * component types.
+	 *
+	 * @param types
+	 *			one of the types the entity must possess
+	 *
+	 * @return an aspect that can be matched against entities
+	 */
+	public static Aspect.Builder one(
+			Collection<Class<? extends Component>> types) {
 		return new Builder().one(types);
 	}
-	
+
 	/**
 	 * Creates an aspect where an entity must possess all of the specified
 	 * component types.
@@ -211,8 +262,9 @@ public class Aspect {
 	 * @deprecated see {@link #all(Class[])}
 	 */
 	@Deprecated
-	public static Aspect.Builder getAspectForAll(Class<? extends Component>... types) {
-		return all(types);
+	public static Aspect.Builder getAspectForAll(
+			Class<? extends Component>... types) {
+		return all(Arrays.asList(types));
 	}
 
 	/**
@@ -226,15 +278,16 @@ public class Aspect {
 	 * @deprecated see {@link #one(Class[])}
 	 */
 	@Deprecated
-	public static Aspect.Builder getAspectForOne(Class<? extends Component>... types) {
-		return one(types);
+	public static Aspect.Builder getAspectForOne(
+			Class<? extends Component>... types) {
+		return one(Arrays.asList(types));
 	}
-	
+
 	/**
-	 * Prior to version 0.9.0, this method returned an aspect which matched no entities.
-	 * This behavior is now reversed - an empty aspect matches everything. To create an
-	 * aspect matching no entities, simply pass null to the {@link com.artemis.EntitySystem}
-	 * constructor.
+	 * Prior to version 0.9.0, this method returned an aspect which matched no
+	 * entities. This behavior is now reversed - an empty aspect matches
+	 * everything. To create an aspect matching no entities, simply pass null to
+	 * the {@link com.artemis.EntitySystem} constructor.
 	 *
 	 * @return an empty Aspect that will reject all entities
 	 */
@@ -258,19 +311,15 @@ public class Aspect {
 		 * Returns an aspect where an entity must possess all of the specified
 		 * component types.
 		 *
-		 * @param types
+		 * @param type
 		 *			a required component type
 		 *
 		 * @return an aspect that can be matched against entities
 		 */
-		public Builder all(Class<? extends Component>... types) {
-			for (Class<? extends Component> t : types) {
-				allTypes.add(t);
-			}
-
+		public Builder all(Class<? extends Component> type) {
+			allTypes.add(type);
 			return this;
 		}
-
 
 		/**
 		 * Returns an aspect where an entity must possess all of the specified
@@ -278,6 +327,25 @@ public class Aspect {
 		 *
 		 * @param types
 		 *			a required component type
+		 *
+		 * @return an aspect that can be matched against entities
+		 */
+		public Builder all(Class<? extends Component> type,
+				Class<? extends Component>... types) {
+			allTypes.add(type);
+			for (Class<? extends Component> t : types) {
+				allTypes.add(t);
+			}
+
+			return this;
+		}
+
+		/**
+		 * Returns an aspect where an entity must possess all of the specified
+		 * component types.
+		 *
+		 * @param types
+		 * 			a required component type
 		 *
 		 * @return an aspect that can be matched against entities
 		 */
@@ -293,12 +361,30 @@ public class Aspect {
 		 * Returns an aspect where an entity must possess one of the specified
 		 * component types.
 		 *
+		 * @param type
+		 *			one of the types the entity must possess
+		 *
+		 * @return an aspect that can be matched against entities
+		 */
+		public Builder one(Class<? extends Component> type) {
+			oneTypes.add(type);
+
+			return this;
+		}
+
+		/**
+		 * Returns an aspect where an entity must possess one of the specified
+		 * component types.
+		 *
 		 * @param types
 		 *			one of the types the entity must possess
 		 *
 		 * @return an aspect that can be matched against entities
 		 */
-		public Builder one(Class<? extends Component>... types) {
+		public Builder one(Class<? extends Component> type,
+				Class<? extends Component>... types) {
+			oneTypes.add(type);
+
 			for (Class<? extends Component> t : types)
 				oneTypes.add(t);
 
@@ -321,12 +407,28 @@ public class Aspect {
 			return this;
 		}
 
+		/**
+		 * Excludes all of the specified component types from the aspect.
+		 * <p>
+		 * A system will not be interested in an entity that possesses one of
+		 * the specified exclusion component types.
+		 * </p>
+		 *
+		 * @param type
+		 *			component type to exclude
+		 *
+		 * @return an aspect that can be matched against entities
+		 */
+		public Builder exclude(Class<? extends Component> type) {
+			exclusionTypes.add(type);
+			return this;
+		}
 
 		/**
 		 * Excludes all of the specified component types from the aspect.
 		 * <p>
-		 * A system will not be interested in an entity that possesses one of the
-		 * specified exclusion component types.
+		 * A system will not be interested in an entity that possesses one of
+		 * the specified exclusion component types.
 		 * </p>
 		 *
 		 * @param types
@@ -334,18 +436,19 @@ public class Aspect {
 		 *
 		 * @return an aspect that can be matched against entities
 		 */
-		public Builder exclude(Class<? extends Component>... types) {
+		public Builder exclude(Class<? extends Component> type,
+				Class<? extends Component>... types) {
+			exclusionTypes.add(type);
 			for (Class<? extends Component> t : types)
 				exclusionTypes.add(t);
 			return this;
 		}
 
-
 		/**
 		 * Excludes all of the specified component types from the aspect.
 		 * <p>
-		 * A system will not be interested in an entity that possesses one of the
-		 * specified exclusion component types.
+		 * A system will not be interested in an entity that possesses one of
+		 * the specified exclusion component types.
 		 * </p>
 		 *
 		 * @param types
@@ -370,7 +473,8 @@ public class Aspect {
 			return aspect;
 		}
 
-		private static void associate(ComponentTypeFactory tf, Bag<Class<? extends Component>> types, BitSet componentBits) {
+		private static void associate(ComponentTypeFactory tf,
+				Bag<Class<? extends Component>> types, BitSet componentBits) {
 			for (Class<? extends Component> t : types) {
 				componentBits.set(tf.getIndexFor(t));
 			}
@@ -378,8 +482,10 @@ public class Aspect {
 
 		@Override
 		public boolean equals(Object o) {
-			if (this == o) return true;
-			if (o == null || getClass() != o.getClass()) return false;
+			if (this == o)
+				return true;
+			if (o == null || getClass() != o.getClass())
+				return false;
 
 			Builder builder = (Builder) o;
 
@@ -400,5 +506,9 @@ public class Aspect {
 			result = 31 * result + oneTypes.hashCode();
 			return result;
 		}
+	}
+
+	public static Builder empty() {
+		return new Builder();
 	}
 }

--- a/artemis/src/main/java/com/artemis/ComponentPool.java
+++ b/artemis/src/main/java/com/artemis/ComponentPool.java
@@ -1,8 +1,5 @@
 package com.artemis;
 
-import java.util.IdentityHashMap;
-import java.util.Map;
-
 import com.artemis.utils.Bag;
 import com.artemis.utils.reflect.ClassReflection;
 import com.artemis.utils.reflect.ReflectionException;

--- a/artemis/src/main/java/com/artemis/PackedComponentMapper.java
+++ b/artemis/src/main/java/com/artemis/PackedComponentMapper.java
@@ -54,7 +54,6 @@ class PackedComponentMapper<A extends PackedComponent> extends ComponentMapper<A
 	}
 
 	@Override
-	@SuppressWarnings("unchecked")
 	public A get(int entityId) throws ArrayIndexOutOfBoundsException {
 		return get(world.getEntity(entityId));
 	}

--- a/artemis/src/main/java/com/artemis/World.java
+++ b/artemis/src/main/java/com/artemis/World.java
@@ -225,7 +225,7 @@ public class World {
 	}
 	
 	@SuppressWarnings("unchecked")
-	public <T extends EntityFactory> T createFactory(Class<?> factory) {
+	public <T extends EntityFactory<?>> T createFactory(Class<?> factory) {
 		if (!factory.isInterface())
 			throw new MundaneWireException("Expected interface for type: " + factory);
 		

--- a/artemis/src/main/java/com/artemis/systems/DelayedEntityProcessingSystem.java
+++ b/artemis/src/main/java/com/artemis/systems/DelayedEntityProcessingSystem.java
@@ -3,8 +3,6 @@ package com.artemis.systems;
 import com.artemis.Aspect;
 import com.artemis.Entity;
 import com.artemis.EntitySystem;
-import com.artemis.utils.Bag;
-import com.artemis.utils.IntBag;
 
 
 /**

--- a/artemis/src/main/java/com/artemis/systems/IntervalEntityProcessingSystem.java
+++ b/artemis/src/main/java/com/artemis/systems/IntervalEntityProcessingSystem.java
@@ -2,8 +2,6 @@ package com.artemis.systems;
 
 import com.artemis.Aspect;
 import com.artemis.Entity;
-import com.artemis.utils.Bag;
-import com.artemis.utils.ImmutableBag;
 import com.artemis.utils.IntBag;
 
 

--- a/artemis/src/main/java/com/artemis/utils/ArtemisProfiler.java
+++ b/artemis/src/main/java/com/artemis/utils/ArtemisProfiler.java
@@ -1,7 +1,6 @@
 package com.artemis.utils;
 
 import com.artemis.BaseSystem;
-import com.artemis.EntitySystem;
 import com.artemis.World;
 import com.artemis.annotations.Profile;
 

--- a/artemis/src/main/java/com/artemis/utils/Bag.java
+++ b/artemis/src/main/java/com/artemis/utils/Bag.java
@@ -392,7 +392,8 @@ public class Bag<E> implements ImmutableBag<E> {
 		if (this == o) return true;
 		if (o == null || getClass() != o.getClass()) return false;
 
-		Bag bag = (Bag) o;
+		@SuppressWarnings("unchecked")
+		Bag<E> bag = (Bag<E>) o;
 		return size == bag.size() && Arrays.equals(data, bag.data);
 	}
 

--- a/artemis/src/test/java/com/artemis/EntitySystemTest.java
+++ b/artemis/src/test/java/com/artemis/EntitySystemTest.java
@@ -5,10 +5,7 @@ import static org.junit.Assert.assertEquals;
 import java.util.NoSuchElementException;
 
 import com.artemis.systems.EntityProcessingSystem;
-import com.artemis.utils.IntBag;
 import org.junit.Test;
-
-import com.artemis.utils.ImmutableBag;
 
 /**
  * Created by obartley on 6/9/14.
@@ -66,7 +63,6 @@ public class EntitySystemTest {
 	public static class IteratorTestSystem extends EntitySystem {
 		public int expectedSize;
 		
-		@SuppressWarnings("unchecked")
 		public IteratorTestSystem(int expectedSize) {
 			super(Aspect.all(C.class));
 			this.expectedSize = expectedSize;
@@ -95,7 +91,7 @@ public class EntitySystemTest {
 
 	public static class EmptySystem extends EntityProcessingSystem {
 		public EmptySystem() {
-			super(Aspect.all());
+			super(Aspect.empty());
 		}
 
 		@Override

--- a/artemis/src/test/java/com/artemis/PerformerWorldTest.java
+++ b/artemis/src/test/java/com/artemis/PerformerWorldTest.java
@@ -1,9 +1,7 @@
 package com.artemis;
 
 import org.junit.After;
-import org.junit.AfterClass;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Test;
 
 import com.artemis.systems.EntityProcessingSystem;

--- a/artemis/src/test/java/com/artemis/WorldTest.java
+++ b/artemis/src/test/java/com/artemis/WorldTest.java
@@ -11,7 +11,6 @@ import com.artemis.component.ComponentX;
 import com.artemis.component.ComponentY;
 import com.artemis.systems.DelayedEntityProcessingSystem;
 import com.artemis.systems.EntityProcessingSystem;
-import com.artemis.systems.VoidEntitySystem;
 import com.artemis.utils.Bag;
 
 public class WorldTest


### PR DESCRIPTION
Hello, 

I got tired of the eclipse warnings for varargs. I improved the fluent api for aspects a bit so that we can avoid varargs and do:
```
aspect.all(One.class).all(Two.class)
```

The new functions need better naming, too. I also added new function Aspect.empty() to create empty AspectBuilders.


I had pretty hard time setting up the project. Ideally I'd need someone to guide me through setting up the project so that it compiles (I get maven plugin error) or test this pull request for me so that i compiles. Non-compiling maven projects are a mess.