### PR TITLE
Removed repeated code.

### DIFF
--- a/artemis/src/main/java/com/artemis/managers/UuidEntityManager.java
+++ b/artemis/src/main/java/com/artemis/managers/UuidEntityManager.java
@@ -28,10 +28,6 @@ public class UuidEntityManager extends Manager {
 	}
 	
 	public void updatedUuid(Entity e, UUID newUuid) {
-		UUID oldUuid = entityToUuid.safeGet(e.getId());
-		if (oldUuid != null)
-			uuidToEntity.remove(oldUuid);
-		
 		setUuid(e, newUuid);
 	}
 	


### PR DESCRIPTION
For some reason, in the `UuidEntityManager` class, the method `updatedUuid` repeates what `setUuid` does, then calls `setUuid`!

It's a small edit, check the code to understand what I mean. Am I missing something here?