### PR TITLE
Add getTag method to TagManager

### DIFF
--- a/artemis/src/main/java/com/artemis/managers/TagManager.java
+++ b/artemis/src/main/java/com/artemis/managers/TagManager.java
@@ -85,6 +85,18 @@ public class TagManager extends Manager {
 	}
 
 	/**
+	 * Get the tag the given entity is tagged with.
+	 *
+	 * @param entity
+	 *			the entity
+	 *
+	 * @return the tag
+	 */
+	public String getTag(Entity entity) {
+		return tagsByEntity.get(entity);
+	}
+
+	/**
 	 * Get all used tags.
 	 *
 	 * @return all used tags as collection


### PR DESCRIPTION
I added a getTag method to TagManager, since the info is available and just the method is missing.

This could be used for example in the tag bit in the new EntitySerializer.