### PR TITLE
Add entity id get/has to componentmapper

### DIFF
--- a/artemis-gwt/src/test/java/com/artemis/component/Packed.java
+++ b/artemis-gwt/src/test/java/com/artemis/component/Packed.java
@@ -8,8 +8,8 @@ public class Packed extends PackedComponent
 	public int entityId;
 
 	@Override
-	protected void forEntity(Entity e) {
-		entityId = e.getId();
+	protected void forEntity(int entityId) {
+		this.entityId = entityId;
 //		return this;
 	}
 

--- a/artemis-test/src/main/java/com/artemis/component/PackedWeaverReference.java
+++ b/artemis-test/src/main/java/com/artemis/component/PackedWeaverReference.java
@@ -34,8 +34,8 @@ public class PackedWeaverReference extends PackedComponent implements DisposedWi
 	}
 
 	@Override
-	protected void forEntity(Entity e) {
-		this.$stride = $_SIZE_OF * e.getId();
+	protected void forEntity(int entityId) {
+		this.$stride = $_SIZE_OF * entityId;
 	}
 
 	@Override

--- a/artemis-test/src/main/java/com/artemis/component/TransPackedFloatReference.java
+++ b/artemis-test/src/main/java/com/artemis/component/TransPackedFloatReference.java
@@ -14,8 +14,8 @@ public class TransPackedFloatReference extends PackedComponent {
 	
 
 	@Override
-	protected void forEntity(Entity e) {
-		this.$stride = $_SIZE_OF * e.getId();
+	protected void forEntity(int entityId) {
+		this.$stride = $_SIZE_OF * entityId;
 	}
 
 	@Override

--- a/artemis-weaver/src/main/java/com/artemis/meta/MetaScanner.java
+++ b/artemis-weaver/src/main/java/com/artemis/meta/MetaScanner.java
@@ -84,7 +84,7 @@ public class MetaScanner extends ClassVisitor implements Opcodes {
 	public MethodVisitor visitMethod(int access, String name, String desc, String signature, String[] exceptions) {
 		if ("reset".equals(name) && "()V".equals(desc))
 			info.foundReset = true;
-		else if ("forEntity".equals(name) && desc.startsWith("(Lcom/artemis/Entity;)"))
+		else if ("forEntity".equals(name) && desc.startsWith("(I)"))
 			info.foundEntityFor = true;
 		else if ("begin".equals(name) && "()V".equals(desc))
 			info.foundBegin = true;

--- a/artemis-weaver/src/main/java/com/artemis/weaver/packed/PackedStubs.java
+++ b/artemis-weaver/src/main/java/com/artemis/weaver/packed/PackedStubs.java
@@ -332,15 +332,14 @@ public class PackedStubs implements Opcodes {
 	private void injectForEntity() {
 		String owner = meta.type.getInternalName();
 		
-		MethodVisitor mv = cw.visitMethod(ACC_PROTECTED, "forEntity", "(Lcom/artemis/Entity;)V", null, null);
+		MethodVisitor mv = cw.visitMethod(ACC_PROTECTED, "forEntity", "(I)V", null, null);
 		mv.visitCode();
 		Label l0 = new Label();
 		mv.visitLabel(l0);
 		if (instanceFields(meta).size() > 0) {
 			mv.visitVarInsn(ALOAD, 0);
 			mv.visitFieldInsn(GETSTATIC, owner, "$_SIZE_OF", "I");
-			mv.visitVarInsn(ALOAD, 1);
-			mv.visitMethodInsn(INVOKEVIRTUAL, "com/artemis/Entity", "getId", "()I", false);
+			mv.visitVarInsn(ILOAD, 1);
 			mv.visitInsn(IMUL);
 			mv.visitFieldInsn(PUTFIELD, owner, "$stride", "I");
 			Label l1 = new Label();
@@ -350,7 +349,7 @@ public class PackedStubs implements Opcodes {
 		Label l2 = new Label();
 		mv.visitLabel(l2);
 		mv.visitLocalVariable("this", "Lcom/artemis/component/TransPackedFloatReference;", null, l0, l2, 0);
-		mv.visitLocalVariable("e", "Lcom/artemis/Entity;", null, l0, l2, 1);
+		mv.visitLocalVariable("entityId", "I", null, l0, l2, 1);
 		mv.visitEnd();
 	}
 	

--- a/artemis-weaver/src/test/java/com/artemis/component/PackedToBeA.java
+++ b/artemis-weaver/src/test/java/com/artemis/component/PackedToBeA.java
@@ -8,7 +8,7 @@ import com.artemis.annotations.PackedWeaver;
 public class PackedToBeA extends Component {
 	private boolean hasBeenReset;
 	
-	void forEntity(Entity e) {
+	void forEntity(int entityId) {
 		
 	}
 }

--- a/artemis/src/main/java/com/artemis/BasicComponentMapper.java
+++ b/artemis/src/main/java/com/artemis/BasicComponentMapper.java
@@ -48,27 +48,25 @@ class BasicComponentMapper<A extends Component> extends ComponentMapper<A> {
 
 	@SuppressWarnings("unchecked")
 	@Override
-	public A getSafe(Entity e) {
-		if(components.isIndexWithinBounds(e.getId())) {
-			return (A) components.get(e.getId());
+	public A getSafe(int entityId) {
+		if(components.isIndexWithinBounds(entityId)) {
+			return (A) components.get(entityId);
 		}
 		return null;
 	}
-	
+
 	@Override
-	public boolean has(Entity e) {
-		return getSafe(e) != null;		
+	public boolean has(int entityId) {
+		return getSafe(entityId) != null;
 	}
 
-
 	@Override
-	public A get(Entity e, boolean forceNewInstance) throws ArrayIndexOutOfBoundsException {
-		return get(e);
+	public A get(int entityId, boolean forceNewInstance) throws ArrayIndexOutOfBoundsException {
+		return get(entityId);
 	}
 
-
 	@Override
-	public A getSafe(Entity e, boolean forceNewInstance) {
-		return getSafe(e);
+	public A getSafe(int entityId, boolean forceNewInstance) {
+		return getSafe(entityId);
 	}
 }

--- a/artemis/src/main/java/com/artemis/ComponentMapper.java
+++ b/artemis/src/main/java/com/artemis/ComponentMapper.java
@@ -29,7 +29,7 @@ public abstract class ComponentMapper<A extends Component> {
 	 * {@link ArrayIndexOutOfBoundsExeption}, however in most scenarios you
 	 * already know the entity possesses this component.
 	 * </p>
-	 * 
+	 *
 	 * @param e
 	 *			the entity that should possess the component
 	 * @param forceNewInstance
@@ -39,7 +39,29 @@ public abstract class ComponentMapper<A extends Component> {
 	 *
 	 * @throws ArrayIndexOutOfBoundsException
 	 */
-	public abstract A get(Entity e, boolean forceNewInstance) throws ArrayIndexOutOfBoundsException;
+	public A get(Entity e, boolean forceNewInstance) throws ArrayIndexOutOfBoundsException
+	{
+		return get(e.getId(), forceNewInstance);
+	}
+
+	/**
+	 * Fast but unsafe retrieval of a component for this entity, by id.
+	 * <p>
+	 * No bounding checks, so this could throw an
+	 * {@link ArrayIndexOutOfBoundsExeption}, however in most scenarios you
+	 * already know the entity possesses this component.
+	 * </p>
+	 *
+	 * @param entityId
+	 *			the entity that should possess the component
+	 * @param forceNewInstance
+	 * 			Returns a new instance of the component (only applies to {@link PackedComponent}s)
+	 *
+	 * @return the instance of the component
+	 *
+	 * @throws ArrayIndexOutOfBoundsException
+	 */
+	public abstract A get(int entityId, boolean forceNewInstance) throws ArrayIndexOutOfBoundsException;
 
 	/**
 	 * Fast and safe retrieval of a component for this entity.
@@ -52,14 +74,30 @@ public abstract class ComponentMapper<A extends Component> {
 	 *
 	 * @return the instance of the component
 	 */
-	public abstract A getSafe(Entity e);
-	
+	public A getSafe(Entity e)
+	{
+		return getSafe(e.getId());
+	}
+
+	/**
+	 * Fast and safe retrieval of a component for this entity by id.
+	 * <p>
+	 * If the entity does not have this component then null is returned.
+	 * </p>
+	 *
+	 * @param entityId
+	 *			the id of entity that should possess the component
+	 *
+	 * @return the instance of the component
+	 */
+	public abstract A getSafe(int entityId);
+
 	/**
 	 * Fast and safe retrieval of a component for this entity.
 	 * <p>
 	 * If the entity does not have this component then null is returned.
 	 * </p>
-	 * 
+	 *
 	 * @param e
 	 *			the entity that should possess the component
 	 * @param forceNewInstance
@@ -67,7 +105,25 @@ public abstract class ComponentMapper<A extends Component> {
 	 *
 	 * @return the instance of the component
 	 */
-	public abstract A getSafe(Entity e, boolean forceNewInstance);
+	public A getSafe(Entity e, boolean forceNewInstance)
+	{
+		return getSafe(e.getId(), forceNewInstance);
+	}
+
+	/**
+	 * Fast and safe retrieval of a component for this entity, by id.
+	 * <p>
+	 * If the entity does not have this component then null is returned.
+	 * </p>
+	 *
+	 * @param entityId
+	 *			the entity id that should possess the component
+	 * @param forceNewInstance
+	 * 			If true, returns a new instance of the component (only applies to {@link PackedComponent}s)
+	 *
+	 * @return the instance of the component
+	 */
+	public abstract A getSafe(int entityId, boolean forceNewInstance);
 
 	/**
 	 * Checks if the entity has this type of component.
@@ -77,8 +133,20 @@ public abstract class ComponentMapper<A extends Component> {
 	 *
 	 * @return true if the entity has this component type, false if it doesn't
 	 */
-	public abstract boolean has(Entity e);
+	public boolean has(Entity e) throws ArrayIndexOutOfBoundsException
+	{
+		return has(e.getId());
+	}
 
+	/**
+	 * Checks if the entity has this type of component.
+	 *
+	 * @param entityId
+	 *			the id of entity to check
+	 *
+	 * @return true if the entity has this component type, false if it doesn't
+	 */
+	public abstract boolean has(int entityId);
 
 	/**
 	 * Returns a component mapper for this type of components.

--- a/artemis/src/main/java/com/artemis/PackedComponent.java
+++ b/artemis/src/main/java/com/artemis/PackedComponent.java
@@ -22,9 +22,22 @@ public abstract class PackedComponent extends Component {
 	 * Sets the currently processed entity. Automatically
 	 * called by {@link PackedComponentMapper}.
 	 *
-	 * @param e Entity to process.
+	 * @param e entity to process.
+	 * @deprecated use #forEntity(int) instead.
 	 */
-	protected abstract void forEntity(Entity e);
+	@Deprecated
+	protected void forEntity(Entity e)
+	{
+		forEntity(e.getId());
+	}
+
+	/**
+	 * Sets the currently processed entity. Automatically
+	 * called by {@link PackedComponentMapper}.
+	 *
+	 * @param entityId id of entity to process.
+	 */
+	protected abstract void forEntity(int entityId);
 
 	/**
 	 * Internal method, used by the {@link ComponentManager},

--- a/artemis/src/main/java/com/artemis/PackedComponentMapper.java
+++ b/artemis/src/main/java/com/artemis/PackedComponentMapper.java
@@ -56,41 +56,35 @@ class PackedComponentMapper<A extends PackedComponent> extends ComponentMapper<A
 	@Override
 	@SuppressWarnings("unchecked")
 	public A get(int entityId) throws ArrayIndexOutOfBoundsException {
-		return get(world.getEntity(entityId));
-	}
-
-	@Override
-	@SuppressWarnings("unchecked")
-	public A get(Entity e) throws ArrayIndexOutOfBoundsException {
-		component.forEntity(e);
+		component.forEntity(entityId);
 		return (A) component;
 	}
 
 	@Override
-	public A getSafe(Entity e) {
-		return has(e) ? get(e) : null;
+	public A getSafe(int entityId) {
+		return has(entityId) ? get(entityId) : null;
 	}
 	
 	@Override
-	public boolean has(Entity e) {
-		return owners.get(e.getId());
+	public boolean has(int entityId) {
+		return owners.get(entityId);
 	}
 
 	@Override
-	public A get(Entity e, boolean forceNewInstance) throws ArrayIndexOutOfBoundsException {
+	public A get(int entityId, boolean forceNewInstance) throws ArrayIndexOutOfBoundsException {
 		if (forceNewInstance) {
 			A c = newInstance();
-			c.forEntity(e);
+			c.forEntity(entityId);
 			return c;
 		} else {
-			return get(e);
+			return get(entityId);
 		}
 	}
 
 	@Override
-	public A getSafe(Entity e, boolean forceNewInstance) {
-		if (has(e)) {
-			return get(e, forceNewInstance);
+	public A getSafe(int entityId, boolean forceNewInstance) {
+		if (has(entityId)) {
+			return get(entityId, forceNewInstance);
 		} else {
 			return null;
 		}

--- a/artemis/src/test/java/com/artemis/ComponentManagerTest.java
+++ b/artemis/src/test/java/com/artemis/ComponentManagerTest.java
@@ -80,9 +80,8 @@ public class ComponentManagerTest {
 		public int entityId;
 		
 		@Override
-		protected void forEntity(Entity e) {
-			entityId = e.getId();
-//			return this;
+		protected void forEntity(int entityId) {
+			this.entityId = entityId;
 		}
 		
 		@Override
@@ -103,9 +102,8 @@ public class ComponentManagerTest {
 		}
 		
 		@Override
-		protected void forEntity(Entity e) {
-			entityId = e.getId();
-//			return this;
+		protected void forEntity(int entityId) {
+			this.entityId = entityId;
 		}
 
 		@Override

--- a/artemis/src/test/java/com/artemis/component/Packed.java
+++ b/artemis/src/test/java/com/artemis/component/Packed.java
@@ -8,9 +8,8 @@ public class Packed extends PackedComponent
 	public int entityId;
 
 	@Override
-	protected void forEntity(Entity e) {
-		entityId = e.getId();
-//		return this;
+	protected void forEntity(int entityId) {
+		this.entityId = entityId;
 	}
 
 	@Override


### PR DESCRIPTION
Adds get/has for entity id. Rewires entity methods via entity id methods.  Fixes #287

@Junkdog please review:
- Bytecode https://github.com/junkdog/artemis-odb/commit/6c490d0c9f941e59256b7734ff101aa0d6a0c97b (outside my expertise). 
- Overal contract.

Do you plan to deprecate Entity completely in 1.0?