### PR TITLE
@SkipWire on types and fields

### DIFF
--- a/artemis/src/main/java/com/artemis/annotations/SkipWire.java
+++ b/artemis/src/main/java/com/artemis/annotations/SkipWire.java
@@ -1,0 +1,19 @@
+package com.artemis.annotations;
+
+import com.artemis.*;
+
+import java.lang.annotation.*;
+
+
+/**
+ * Skip reflective dependency injection on annotated field or class.
+ *
+ * Allows excluding specific fields or classes in {@see Wire}d hierarchy.
+ *
+ * @author Daan van Yperen
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.FIELD, ElementType.TYPE})
+@Documented
+public @interface SkipWire {
+}

--- a/artemis/src/main/java/com/artemis/injection/CachedField.java
+++ b/artemis/src/main/java/com/artemis/injection/CachedField.java
@@ -28,6 +28,7 @@ public class CachedField {
     /**
      * {@link WireType#WIRE} if the field is annotated with {@link com.artemis.annotations.Wire},
      * {@link WireType#MAPPER} if the field is annotated with {@link com.artemis.annotations.Mapper},
+     * {@link WireType#SKIPWIRE} if the field is annotated with {@link com.artemis.annotations.SkipWire),
      * {@link WireType#IGNORED} otherwise.
      */
     public final WireType wireType;

--- a/artemis/src/main/java/com/artemis/injection/CachedInjector.java
+++ b/artemis/src/main/java/com/artemis/injection/CachedInjector.java
@@ -1,11 +1,6 @@
 package com.artemis.injection;
 
-import com.artemis.BaseSystem;
-import com.artemis.ComponentMapper;
-import com.artemis.Manager;
-import com.artemis.MundaneWireException;
-import com.artemis.World;
-import com.artemis.WorldConfiguration;
+import com.artemis.*;
 import com.artemis.utils.reflect.ClassReflection;
 import com.artemis.utils.reflect.Field;
 import com.artemis.utils.reflect.ReflectionException;
@@ -21,143 +16,154 @@ import java.util.Map;
  * Caches all type-information.
  *
  * <p>
- *  For greater control over the dependency-resolution, provide a {@link FieldHandler} to {@link #setFieldHandler(FieldHandler)},
- *  which will be used to resolve dependency values instead.
+ * For greater control over the dependency-resolution, provide a {@link FieldHandler} to {@link #setFieldHandler(FieldHandler)},
+ * which will be used to resolve dependency values instead.
  * </p>
  *
  * @author Arni Arent
  * @author Snorre E. Brekke
- *
  * @see com.artemis.injection.FieldHandler
  */
 public final class CachedInjector implements Injector {
-    private InjectionCache cache = new InjectionCache();
-    private FieldHandler fieldHandler;
+	private InjectionCache cache = new InjectionCache();
+	private FieldHandler fieldHandler;
 
-    @Override
-    public Injector setFieldHandler(FieldHandler fieldHandler) {
-        this.fieldHandler = fieldHandler;
-        return this;
-    }
+	@Override
+	public Injector setFieldHandler(FieldHandler fieldHandler) {
+		this.fieldHandler = fieldHandler;
+		return this;
+	}
 
-    @Override
-    public void initialize(World world, Map<String, Object> injectables) {
-        if (fieldHandler == null) {
-            fieldHandler = new FieldHandler(cache, injectables);
-        }
-        fieldHandler.initialize(world);
-    }
+	@Override
+	public void initialize(World world, Map<String, Object> injectables) {
+		if (fieldHandler == null) {
+			fieldHandler = new FieldHandler(cache, injectables);
+		}
+		fieldHandler.initialize(world);
+	}
 
-    @Override
-    public boolean isInjectable(Object target) {
-        try {
-            CachedClass cachedClass = cache.getCachedClass(target.getClass());
-            return cachedClass.wireType == WireType.WIRE;
-        } catch (ReflectionException e) {
-            throw new MundaneWireException("Error while wiring", e);
-        }
-    }
+	@Override
+	public boolean isInjectable(Object target) {
+		try {
+			CachedClass cachedClass = cache.getCachedClass(target.getClass());
+			return cachedClass.wireType == WireType.WIRE;
+		} catch (ReflectionException e) {
+			throw new MundaneWireException("Error while wiring", e);
+		}
+	}
 
-    @Override
-    public void inject(Object target) throws RuntimeException {
-        try {
-            Class<?> clazz = target.getClass();
-            CachedClass cachedClass = cache.getCachedClass(clazz);
+	@Override
+	public void inject(Object target) throws RuntimeException {
+		try {
+			Class<?> clazz = target.getClass();
+			CachedClass cachedClass = cache.getCachedClass(clazz);
 
-            if (cachedClass.wireType == WireType.WIRE) {
-                injectValidFields(target, cachedClass);
-            } else {
-                injectAnnotatedFields(target, cachedClass);
-            }
-        } catch (ReflectionException e) {
-            throw new MundaneWireException("Error while wiring", e);
-        }
-    }
+			if (cachedClass.wireType == WireType.WIRE) {
+				injectValidFields(target, cachedClass);
+			} else {
+				injectAnnotatedFields(target, cachedClass);
+			}
+		} catch (ReflectionException e) {
+			throw new MundaneWireException("Error while wiring", e);
+		}
+	}
 
-    private void injectValidFields(Object target, CachedClass cachedClass)
-            throws ReflectionException {
-        Field[] declaredFields = getAllFields(cachedClass);
-        for (int i = 0, s = declaredFields.length; s > i; i++) {
-            injectField(target, declaredFields[i], cachedClass.failOnNull);
-        }
-    }
+	private void injectValidFields(Object target, CachedClass cachedClass)
+			throws ReflectionException {
+		Field[] declaredFields = getAllInjectableFields(cachedClass);
+		for (int i = 0, s = declaredFields.length; s > i; i++) {
+			injectField(target, declaredFields[i], cachedClass.failOnNull);
+		}
+	}
 
-    private Field[] getAllFields(CachedClass cachedClass) {
-        Field[] declaredFields = cachedClass.allFields;
-        if (declaredFields == null) {
-            List<Field> fieldList = new ArrayList<Field>();
-            Class<?> clazz = cachedClass.clazz;
-            collectDeclaredFields(fieldList, clazz);
+	private Field[] getAllInjectableFields(CachedClass cachedClass) {
+		Field[] declaredFields = cachedClass.allFields;
+		if (declaredFields == null) {
+			List<Field> fieldList = new ArrayList<Field>();
+			Class<?> clazz = cachedClass.clazz;
+			collectDeclaredInjectableFields(fieldList, clazz);
 
-            while (cachedClass.injectInherited && (clazz = clazz.getSuperclass()) != Object.class) {
-                collectDeclaredFields(fieldList, clazz);
-            }
-            cachedClass.allFields = declaredFields = fieldList.toArray(new Field[fieldList.size()]);
-        }
-        return declaredFields;
-    }
+			while (cachedClass.injectInherited && (clazz = clazz.getSuperclass()) != Object.class) {
+				collectDeclaredInjectableFields(fieldList, clazz);
+			}
+			cachedClass.allFields = declaredFields = fieldList.toArray(new Field[fieldList.size()]);
+		}
+		return declaredFields;
+	}
 
-    private void collectDeclaredFields(List<Field> fieldList, Class<?> clazz) {
-        Field[] classFields = ClassReflection.getDeclaredFields(clazz);
-        for (int i = 0; i < classFields.length; i++) {
-            fieldList.add(classFields[i]);
-        }
-    }
+	private void collectDeclaredInjectableFields(List<Field> fieldList, Class<?> clazz) {
+		try {
+			if (cache.getCachedClass(clazz).wireType != WireType.SKIPWIRE) {
+				Field[] classFields = ClassReflection.getDeclaredFields(clazz);
+				for (int i = 0; i < classFields.length; i++) {
+					if (isWireable(classFields[i])) {
+						fieldList.add(classFields[i]);
+					}
+				}
+			}
+		} catch (ReflectionException e) {
+			throw new MundaneWireException("Error while wiring", e);
+		}
+	}
 
-    private void injectAnnotatedFields(Object target, CachedClass cachedClass)
-            throws ReflectionException {
-        injectClass(target, cachedClass);
-    }
+	private boolean isWireable(Field field) {
+		return cache.getCachedField(field).wireType != WireType.SKIPWIRE;
+	}
 
-    @SuppressWarnings("deprecation")
-    private void injectClass(Object target, CachedClass cachedClass) throws ReflectionException {
-        Field[] declaredFields = getAllFields(cachedClass);
-        for (int i = 0, s = declaredFields.length; s > i; i++) {
-            Field field = declaredFields[i];
-            CachedField cachedField = cache.getCachedField(field);
-            if (cachedField.wireType != WireType.IGNORED) {
-                injectField(target, field, cachedField.wireType == WireType.WIRE);
-            }
-        }
-    }
+	private void injectAnnotatedFields(Object target, CachedClass cachedClass)
+			throws ReflectionException {
+		injectClass(target, cachedClass);
+	}
 
-    @SuppressWarnings("unchecked")
-    private void injectField(Object target, Field field, boolean failOnNotInjected)
-            throws ReflectionException {
-        Class<?> fieldType;
-        try {
-            fieldType = field.getType();
-        } catch (RuntimeException ignore) {
-            // Swallow exception caused by missing typedata on gwt platfString.format("Failed to inject %s into %s:
-            // %s not registered with world.")orm.
-            // @todo Workaround, awaiting junkdog-ification. Silently failing injections might be undesirable for
-            // users failing to add systems/components to gwt reflection inclusion config.
-            return;
-        }
+	@SuppressWarnings("deprecation")
+	private void injectClass(Object target, CachedClass cachedClass) throws ReflectionException {
+		Field[] declaredFields = getAllInjectableFields(cachedClass);
+		for (int i = 0, s = declaredFields.length; s > i; i++) {
+			Field field = declaredFields[i];
+			CachedField cachedField = cache.getCachedField(field);
+			if (cachedField.wireType != WireType.IGNORED) {
+				injectField(target, field, cachedField.wireType == WireType.WIRE);
+			}
+		}
+	}
 
-        Object resolve = fieldHandler.resolve(fieldType, field);
-        if (resolve != null) {
-            setField(target, field, resolve);
-        }
+	@SuppressWarnings("unchecked")
+	private void injectField(Object target, Field field, boolean failOnNotInjected)
+			throws ReflectionException {
+		Class<?> fieldType;
+		try {
+			fieldType = field.getType();
+		} catch (RuntimeException ignore) {
+			// Swallow exception caused by missing typedata on gwt platfString.format("Failed to inject %s into %s:
+			// %s not registered with world.")orm.
+			// @todo Workaround, awaiting junkdog-ification. Silently failing injections might be undesirable for
+			// users failing to add systems/components to gwt reflection inclusion config.
+			return;
+		}
 
-        if (resolve == null && failOnNotInjected && cache.getFieldClassType(fieldType) != ClassType.CUSTOM ) {
-            throw onFailedInjection(fieldType.getSimpleName(), field);
-        }
-    }
+		Object resolve = fieldHandler.resolve(fieldType, field);
+		if (resolve != null) {
+			setField(target, field, resolve);
+		}
 
-    private void setField(Object target, Field field, Object fieldValue) throws ReflectionException {
-        field.setAccessible(true);
-        field.set(target, fieldValue);
-    }
+		if (resolve == null && failOnNotInjected && cache.getFieldClassType(fieldType) != ClassType.CUSTOM) {
+			throw onFailedInjection(fieldType.getSimpleName(), field);
+		}
+	}
 
-    private MundaneWireException onFailedInjection(String typeName, Field failedInjection) {
-        String error = new StringBuilder()
-                .append("Failed to inject ").append(failedInjection.getType().getName())
-                .append(" into ").append(failedInjection.getDeclaringClass().getName()).append(": ")
-                .append(typeName).append(" not registered with world.")
-                .toString();
+	private void setField(Object target, Field field, Object fieldValue) throws ReflectionException {
+		field.setAccessible(true);
+		field.set(target, fieldValue);
+	}
 
-        return new MundaneWireException(error);
-    }
+	private MundaneWireException onFailedInjection(String typeName, Field failedInjection) {
+		String error = new StringBuilder()
+				.append("Failed to inject ").append(failedInjection.getType().getName())
+				.append(" into ").append(failedInjection.getDeclaringClass().getName()).append(": ")
+				.append(typeName).append(" not registered with world.")
+				.toString();
+
+		return new MundaneWireException(error);
+	}
 
 }

--- a/artemis/src/main/java/com/artemis/injection/InjectionCache.java
+++ b/artemis/src/main/java/com/artemis/injection/InjectionCache.java
@@ -5,6 +5,7 @@ import com.artemis.ComponentMapper;
 import com.artemis.EntityFactory;
 import com.artemis.Manager;
 import com.artemis.annotations.Mapper;
+import com.artemis.annotations.SkipWire;
 import com.artemis.annotations.Wire;
 import com.artemis.utils.reflect.ClassReflection;
 import com.artemis.utils.reflect.Field;
@@ -25,13 +26,14 @@ public class InjectionCache {
     private static final Map<Field, CachedField> namedWireCache = new HashMap<Field, CachedField>();
     private static final Map<Field, Class<?>> genericsCache = new HashMap<Field, Class<?>>();
 
-    public CachedClass getCachedClass(Class<?> clazz) throws ReflectionException {
-        CachedClass cachedClass = classCache.get(clazz);
-        if (cachedClass == null) {
-            cachedClass = new CachedClass(clazz);
-            cachedClass.wireType = ClassReflection.isAnnotationPresent(clazz, Wire.class) ?
-                                   WireType.WIRE :
-                                   WireType.IGNORED;
+	public CachedClass getCachedClass(Class<?> clazz) throws ReflectionException {
+		CachedClass cachedClass = classCache.get(clazz);
+		if (cachedClass == null) {
+			cachedClass = new CachedClass(clazz);
+			cachedClass.wireType = ClassReflection.isAnnotationPresent(clazz, Wire.class) ?
+					WireType.WIRE : (ClassReflection.isAnnotationPresent(clazz, SkipWire.class) ?
+					WireType.SKIPWIRE :
+					WireType.IGNORED);
 
             if (cachedClass.wireType == WireType.WIRE) {
                 Wire wireAnnotation = ClassReflection.getAnnotation(clazz, Wire.class);
@@ -45,51 +47,52 @@ public class InjectionCache {
     }
 
 
-    public CachedField getCachedField(Field field) {
-        CachedField cachedField = namedWireCache.get(field);
-        if (cachedField == null) {
-            if (field.isAnnotationPresent(Wire.class)) {
-                final Wire wire = field.getAnnotation(Wire.class);
-                cachedField = new CachedField(field, WireType.WIRE, wire.name());
-            }
-            else if(field.isAnnotationPresent(Mapper.class)) {
-                cachedField = new CachedField(field, WireType.MAPPER, null);
-            }else {
-                cachedField = new CachedField(field, WireType.IGNORED, null);
-            }
-            namedWireCache.put(field, cachedField);
-        }
-        return cachedField;
-    }
+	public CachedField getCachedField(Field field) {
+		CachedField cachedField = namedWireCache.get(field);
+		if (cachedField == null) {
+			if (field.isAnnotationPresent(Wire.class)) {
+				final Wire wire = field.getAnnotation(Wire.class);
+				cachedField = new CachedField(field, WireType.WIRE, wire.name());
+			} else if (field.isAnnotationPresent(Mapper.class)) {
+				cachedField = new CachedField(field, WireType.MAPPER, null);
+			} else if (field.isAnnotationPresent(SkipWire.class)) {
+				cachedField = new CachedField(field, WireType.SKIPWIRE, null);
+			} else {
+				cachedField = new CachedField(field, WireType.IGNORED, null);
+			}
+			namedWireCache.put(field, cachedField);
+		}
+		return cachedField;
+	}
 
 
-    public ClassType getFieldClassType(Class<?> fieldType) {
-        ClassType injectionType = fieldClassTypeCache.get(fieldType);
-        if (injectionType == null) {
-            if (ClassReflection.isAssignableFrom(ComponentMapper.class, fieldType)) {
-                injectionType = ClassType.MAPPER;
-            } else if(ClassReflection.isAssignableFrom(BaseSystem.class, fieldType)) {
-                injectionType = ClassType.SYSTEM;
-            } else if(ClassReflection.isAssignableFrom(Manager.class, fieldType)) {
-                injectionType = ClassType.MANAGER;
-            } else if(ClassReflection.isAssignableFrom(EntityFactory.class, fieldType)){
-                injectionType = ClassType.FACTORY;
-            } else {
-                injectionType = ClassType.CUSTOM;
-            }
-            fieldClassTypeCache.put(fieldType, injectionType);
-        }
-        return injectionType;
-    }
+	public ClassType getFieldClassType(Class<?> fieldType) {
+		ClassType injectionType = fieldClassTypeCache.get(fieldType);
+		if (injectionType == null) {
+			if (ClassReflection.isAssignableFrom(ComponentMapper.class, fieldType)) {
+				injectionType = ClassType.MAPPER;
+			} else if (ClassReflection.isAssignableFrom(BaseSystem.class, fieldType)) {
+				injectionType = ClassType.SYSTEM;
+			} else if (ClassReflection.isAssignableFrom(Manager.class, fieldType)) {
+				injectionType = ClassType.MANAGER;
+			} else if (ClassReflection.isAssignableFrom(EntityFactory.class, fieldType)) {
+				injectionType = ClassType.FACTORY;
+			} else {
+				injectionType = ClassType.CUSTOM;
+			}
+			fieldClassTypeCache.put(fieldType, injectionType);
+		}
+		return injectionType;
+	}
 
-    public Class<?> getGenericType(Field field){
-        Class<?> genericsType = genericsCache.get(field);
-        if (genericsType == null) {
-            genericsType = field.getElementType(0);
-            genericsCache.put(field, genericsType);
-        }
-        return genericsType;
-    }
+	public Class<?> getGenericType(Field field) {
+		Class<?> genericsType = genericsCache.get(field);
+		if (genericsType == null) {
+			genericsType = field.getElementType(0);
+			genericsCache.put(field, genericsType);
+		}
+		return genericsType;
+	}
 
 
 }

--- a/artemis/src/main/java/com/artemis/injection/WireType.java
+++ b/artemis/src/main/java/com/artemis/injection/WireType.java
@@ -1,5 +1,7 @@
 package com.artemis.injection;
 
+import com.artemis.annotations.SkipWire;
+
 /**
  * Enum used by {@link ClassType} to indicate if a class or field is annotated with {@link com.artemis.annotations.Wire}
  * or {@link com.artemis.annotations.Mapper}.
@@ -17,5 +19,9 @@ public enum WireType {
     /**
      * Indicates that a class is not annotated with anything relevant to the artemis-world.
      */
-    IGNORED
+    IGNORED,
+    /**
+     * Indicates that a class is annotated with {@link com.artemis.annotations.SkipWire}
+     */
+    SKIPWIRE
 }

--- a/artemis/src/test/java/com/artemis/SkipWireTest.java
+++ b/artemis/src/test/java/com/artemis/SkipWireTest.java
@@ -1,0 +1,122 @@
+package com.artemis;
+
+import com.artemis.annotations.SkipWire;
+import com.artemis.annotations.Wire;
+import com.artemis.component.ComponentX;
+import com.artemis.component.ComponentY;
+import com.artemis.managers.TagManager;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+/**
+ * @author Daan van Yperen
+ */
+public class SkipWireTest {
+
+	@Test
+	public void ensure_skipped_field_skipped_in_wired_class() {
+
+		@Wire
+		class TestManager extends Manager {
+			private ComponentMapper<ComponentX> x;
+			@SkipWire
+			private ComponentMapper<ComponentY> y;
+		}
+
+
+		TestManager manager = new TestManager();
+		new World(new WorldConfiguration()
+				.setManager(manager));
+
+		assertNotNull(manager.x);
+		assertNull(manager.y);
+	}
+
+	@Test
+	public void ensure_superclass_skipped_field_skipped_in_wired_class() {
+
+		class SuperTestManager extends Manager {
+			protected ComponentMapper<ComponentX> x;
+			@SkipWire
+			protected ComponentMapper<ComponentY> y;
+		}
+
+		@Wire(injectInherited = true)
+		class TestManager extends SuperTestManager {
+		}
+
+
+		TestManager manager = new TestManager();
+		new World(new WorldConfiguration()
+				.setManager(manager));
+
+		assertNotNull(manager.x);
+		assertNull(manager.y);
+	}
+
+
+	@Test
+	public void ensure_skipped_superclass_skipped_in_wired_class() {
+
+		class RootTestManager extends Manager {
+			protected ComponentMapper<ComponentY> z;
+		}
+
+		@SkipWire
+		class SuperTestManager extends RootTestManager {
+			protected ComponentMapper<ComponentY> y;
+		}
+
+		@Wire(injectInherited = true)
+		class TestManager extends SuperTestManager {
+			protected ComponentMapper<ComponentX> x;
+		}
+
+
+		TestManager manager = new TestManager();
+		new World(new WorldConfiguration()
+				.setManager(manager));
+
+		assertNotNull(manager.z);
+		assertNull(manager.y);
+		assertNotNull(manager.x);
+	}
+
+	@Test
+	public void ensure_wire_supersedes_skipwire_on_type() {
+
+		@Wire @SkipWire
+		class TestManager extends Manager {
+			private ComponentMapper<ComponentX> x;
+		}
+
+
+		TestManager manager = new TestManager();
+		new World(new WorldConfiguration()
+				.setManager(manager));
+
+		assertNotNull(manager.x);
+	}
+
+	@Test
+	public void ensure_wire_supersedes_skipwire_on_field() {
+
+
+		class TestManager extends Manager {
+			@Wire @SkipWire
+			private ComponentMapper<ComponentX> x;
+		}
+
+
+		TestManager manager = new TestManager();
+		new World(new WorldConfiguration()
+				.setManager(manager));
+
+		assertNotNull(manager.x);
+	}
+
+}


### PR DESCRIPTION
Implements #334. Allows excluding specific fields or superclasses in a hierarchy from `@Wire`. Example application is API classes with reflection unresolvable ComponentMappers due to generics.

Covered with tests. Prob needs a @snorrees performance pass as well.

Sorry about the messy pull, looks like cached injector uses spaces instead of tabs. Not certain on etiquette.