### PR TITLE
Port ComponentMapper functionality from contrib.

### DIFF
--- a/artemis/src/main/java/com/artemis/BasicComponentMapper.java
+++ b/artemis/src/main/java/com/artemis/BasicComponentMapper.java
@@ -34,6 +34,7 @@ class BasicComponentMapper<A extends Component> extends ComponentMapper<A> {
 	 *			the world to handle components for
 	 */
 	BasicComponentMapper(Class<A> type, World world) {
+		super(type, world);
 		ComponentTypeFactory tf = world.getComponentManager().typeFactory;
 		this.type = tf.getTypeFor(type);
 		components = world.getComponentManager().getComponentsByType(this.type);

--- a/artemis/src/main/java/com/artemis/ComponentMapper.java
+++ b/artemis/src/main/java/com/artemis/ComponentMapper.java
@@ -1,6 +1,17 @@
 package com.artemis;
 
 public abstract class ComponentMapper<A extends Component> {
+
+	private final EntityTransmuter createTransmuter;
+	private final EntityTransmuter removeTransmuter;
+	private final Entity flyweight;
+
+	public <A extends Component> ComponentMapper(Class<A> type, World world) {
+		createTransmuter = new EntityTransmuterFactory(world).add(type).build();
+		removeTransmuter = new EntityTransmuterFactory(world).remove(type).build();
+		flyweight = Entity.createFlyweight(world);
+	}
+
 	/**
 	 * Fast but unsafe retrieval of a component for this entity.
 	 * <p>
@@ -8,12 +19,9 @@ public abstract class ComponentMapper<A extends Component> {
 	 * {@link ArrayIndexOutOfBoundsExeption}, however in most scenarios you
 	 * already know the entity possesses this component.
 	 * </p>
-	 * 
-	 * @param e
-	 *			the entity that should possess the component
 	 *
+	 * @param e the entity that should possess the component
 	 * @return the instance of the component
-	 *
 	 * @throws ArrayIndexOutOfBoundsException
 	 */
 	public A get(Entity e) throws ArrayIndexOutOfBoundsException {
@@ -30,17 +38,12 @@ public abstract class ComponentMapper<A extends Component> {
 	 * already know the entity possesses this component.
 	 * </p>
 	 *
-	 * @param e
-	 *			the entity that should possess the component
-	 * @param forceNewInstance
-	 * 			Returns a new instance of the component (only applies to {@link PackedComponent}s)
-	 *
+	 * @param e                the entity that should possess the component
+	 * @param forceNewInstance Returns a new instance of the component (only applies to {@link PackedComponent}s)
 	 * @return the instance of the component
-	 *
 	 * @throws ArrayIndexOutOfBoundsException
 	 */
-	public A get(Entity e, boolean forceNewInstance) throws ArrayIndexOutOfBoundsException
-	{
+	public A get(Entity e, boolean forceNewInstance) throws ArrayIndexOutOfBoundsException {
 		return get(e.getId(), forceNewInstance);
 	}
 
@@ -52,13 +55,9 @@ public abstract class ComponentMapper<A extends Component> {
 	 * already know the entity possesses this component.
 	 * </p>
 	 *
-	 * @param entityId
-	 *			the entity that should possess the component
-	 * @param forceNewInstance
-	 * 			Returns a new instance of the component (only applies to {@link PackedComponent}s)
-	 *
+	 * @param entityId         the entity that should possess the component
+	 * @param forceNewInstance Returns a new instance of the component (only applies to {@link PackedComponent}s)
 	 * @return the instance of the component
-	 *
 	 * @throws ArrayIndexOutOfBoundsException
 	 */
 	public abstract A get(int entityId, boolean forceNewInstance) throws ArrayIndexOutOfBoundsException;
@@ -68,14 +67,11 @@ public abstract class ComponentMapper<A extends Component> {
 	 * <p>
 	 * If the entity does not have this component then null is returned.
 	 * </p>
-	 * 
-	 * @param e
-	 *			the entity that should possess the component
 	 *
+	 * @param e the entity that should possess the component
 	 * @return the instance of the component
 	 */
-	public A getSafe(Entity e)
-	{
+	public A getSafe(Entity e) {
 		return getSafe(e.getId());
 	}
 
@@ -85,9 +81,7 @@ public abstract class ComponentMapper<A extends Component> {
 	 * If the entity does not have this component then null is returned.
 	 * </p>
 	 *
-	 * @param entityId
-	 *			the id of entity that should possess the component
-	 *
+	 * @param entityId the id of entity that should possess the component
 	 * @return the instance of the component
 	 */
 	public abstract A getSafe(int entityId);
@@ -98,15 +92,11 @@ public abstract class ComponentMapper<A extends Component> {
 	 * If the entity does not have this component then null is returned.
 	 * </p>
 	 *
-	 * @param e
-	 *			the entity that should possess the component
-	 * @param forceNewInstance
-	 * 			If true, returns a new instance of the component (only applies to {@link PackedComponent}s)
-	 *
+	 * @param e                the entity that should possess the component
+	 * @param forceNewInstance If true, returns a new instance of the component (only applies to {@link PackedComponent}s)
 	 * @return the instance of the component
 	 */
-	public A getSafe(Entity e, boolean forceNewInstance)
-	{
+	public A getSafe(Entity e, boolean forceNewInstance) {
 		return getSafe(e.getId(), forceNewInstance);
 	}
 
@@ -116,11 +106,8 @@ public abstract class ComponentMapper<A extends Component> {
 	 * If the entity does not have this component then null is returned.
 	 * </p>
 	 *
-	 * @param entityId
-	 *			the entity id that should possess the component
-	 * @param forceNewInstance
-	 * 			If true, returns a new instance of the component (only applies to {@link PackedComponent}s)
-	 *
+	 * @param entityId         the entity id that should possess the component
+	 * @param forceNewInstance If true, returns a new instance of the component (only applies to {@link PackedComponent}s)
 	 * @return the instance of the component
 	 */
 	public abstract A getSafe(int entityId, boolean forceNewInstance);
@@ -128,43 +115,150 @@ public abstract class ComponentMapper<A extends Component> {
 	/**
 	 * Checks if the entity has this type of component.
 	 *
-	 * @param e
-	 *			the entity to check
-	 *
+	 * @param e the entity to check
 	 * @return true if the entity has this component type, false if it doesn't
 	 */
-	public boolean has(Entity e) throws ArrayIndexOutOfBoundsException
-	{
+	public boolean has(Entity e) throws ArrayIndexOutOfBoundsException {
 		return has(e.getId());
 	}
 
 	/**
 	 * Checks if the entity has this type of component.
 	 *
-	 * @param entityId
-	 *			the id of entity to check
-	 *
+	 * @param entityId the id of entity to check
 	 * @return true if the entity has this component type, false if it doesn't
 	 */
 	public abstract boolean has(int entityId);
 
+
+	/**
+	 * Create component for this entity.
+	 * Will avoid creation if component preexists.
+	 *
+	 * @param entity the entity that should possess the component
+	 * @return the instance of the component.
+	 */
+	public A create(Entity entity) {
+		return create(entity.getId());
+	}
+
+	/**
+	 * Remove component from entity.
+	 * Does nothing if already removed.
+	 *
+	 * @param entityId
+	 */
+	public void remove(int entityId) {
+		if (has(entityId)) {
+			removeTransmuter.transmute(asFlyweight(entityId));
+		}
+	}
+
+	/**
+	 * Remove component from entity.
+	 * Does nothing if already removed.
+	 *
+	 * @param entity entity to remove.
+	 */
+	public void remove(Entity entity) {
+		remove(entity.getId());
+	}
+
+	/**
+	 * Create component for this entity.
+	 * Will avoid creation if component preexists.
+	 *
+	 * @param entityId the entity that should possess the component
+	 * @return the instance of the component.
+	 */
+	public A create(int entityId) {
+		A component = getSafe(entityId);
+		if (component == null) {
+			createTransmuter.transmute(asFlyweight(entityId));
+			component = get(entityId);
+		}
+		return component;
+	}
+
+	/**
+	 * Setup flyweight with ID and return.
+	 * Cannot count on just created entities being resolvable
+	 * in world, which can break transmuters.
+	 */
+	private Entity asFlyweight(int entityId) {
+		flyweight.id = entityId;
+		return flyweight;
+	}
+
+	/**
+	 * Fast and safe retrieval of a component for this entity.
+	 * If the entity does not have this component then fallback is returned.
+	 *
+	 * @param entityId Entity that should possess the component
+	 * @param fallback fallback component to return, or {@code null} to return null.
+	 * @return the instance of the component
+	 */
+	public A getSafe(int entityId, A fallback) {
+		final A c = getSafe(entityId);
+		return (c != null) ? c : fallback;
+	}
+
+	/**
+	 * Create or remove a component from an entity.
+	 *
+	 * Does nothing if already removed or created respectively.
+	 *
+	 * @param entityId Entity id to change.
+	 * @param value {@code true} to create component (if missing), {@code false} to remove (if exists).
+	 * @return the instance of the component, or {@code null} if removed.
+	 */
+	public A set(int entityId, boolean value) {
+		if ( value ) {
+			return create(entityId);
+		} else {
+			remove(entityId);
+			return null;
+		}
+	}
+
+	/**
+	 * Create or remove a component from an entity.
+	 *
+	 * Does nothing if already removed or created respectively.
+	 *
+	 * @param entity Entity to change.
+	 * @param value {@code true} to create component (if missing), {@code false} to remove (if exists).
+	 * @return the instance of the component, or {@code null} if removed.
+	 */
+	public A set(Entity entity, boolean value) {
+		return set(entity.getId(), value);
+	}
+
+	/**
+	 * Fast and safe retrieval of a component for this entity.
+	 * If the entity does not have this component then fallback is returned.
+	 *
+	 * @param entity   Entity that should possess the component
+	 * @param fallback fallback component to return, or {@code null} to return null.
+	 * @return the instance of the component
+	 */
+	public A getSafe(Entity entity, A fallback) {
+		return getSafe(entity.getId(), fallback);
+	}
+
 	/**
 	 * Returns a component mapper for this type of components.
-	 * 
-	 * @param <T>
-	 *			the class type of components
-	 * @param type
-	 *			the class of components this mapper uses
-	 * @param world
-	 *			the world that this component mapper should use
 	 *
+	 * @param <T>   the class type of components
+	 * @param type  the class of components this mapper uses
+	 * @param world the world that this component mapper should use
 	 * @return a new mapper
 	 */
 	@SuppressWarnings("unchecked")
 	public static <T extends Component> ComponentMapper<T> getFor(Class<T> type, World world) {
 		ComponentTypeFactory tf = world.getComponentManager().typeFactory;
 		if (tf.getTypeFor(type).isPackedComponent())
-			return (ComponentMapper<T>)PackedComponentMapper.create((Class<PackedComponent>)type, world);
+			return (ComponentMapper<T>) PackedComponentMapper.create((Class<PackedComponent>) type, world);
 		else
 			return new BasicComponentMapper<T>(type, world);
 	}

--- a/artemis/src/main/java/com/artemis/PackedComponentMapper.java
+++ b/artemis/src/main/java/com/artemis/PackedComponentMapper.java
@@ -38,6 +38,7 @@ class PackedComponentMapper<A extends PackedComponent> extends ComponentMapper<A
 	 *			the world to handle components for
 	 */
 	private PackedComponentMapper(Class<A> componentType, World world) {
+		super(componentType, world);
 		this.world = world;
 		ComponentManager cm = world.getComponentManager();
 		ComponentType type = cm.typeFactory.getTypeFor(componentType);

--- a/artemis/src/test/java/com/artemis/ComponentMapperTest.java
+++ b/artemis/src/test/java/com/artemis/ComponentMapperTest.java
@@ -1,0 +1,252 @@
+package com.artemis;
+
+import com.artemis.annotations.Wire;
+import com.artemis.component.ComponentX;
+import com.artemis.component.ComponentY;
+import com.artemis.systems.EntityProcessingSystem;
+import org.junit.Assert;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+/**
+ * @author Daan van Yperen
+ */
+/**
+ * @author Daan van Yperen
+ */
+public class ComponentMapperTest {
+
+	public static class Pos extends Component { public int x,y; public Pos() {} public Pos(int x, int y){ this.x=x;this.y=y; } }
+	public static class TestMarker extends Component {}
+
+	@Wire
+	public class BasicSystem extends EntityProcessingSystem {
+
+		public BasicSystem() {
+			super(Aspect.all(TestMarker.class));
+		}
+
+		protected ComponentMapper<Pos> mPos;
+
+		@Override
+		protected void process(Entity e) {
+		}
+	}
+
+	@Test
+	public void create_if_missing_should_create_new_component() {
+
+		@Wire(injectInherited = true)
+		class TestSystemA extends BasicSystem {
+			@Override
+			protected void process(Entity e) {
+				Pos c = mPos.create(e);
+				Assert.assertNotNull(c);
+			}
+		}
+
+		createAndProcessWorld(new TestSystemA());
+	}
+
+	@Test
+	public void create_if_exists_should_recycle_existing_component() {
+
+		@Wire(injectInherited = true)
+		class TestSystem extends BasicSystem {
+			@Override
+			protected void process(Entity e) {
+				Pos c1 = mPos.create(e);
+				Pos c2 = mPos.create(e);
+				Assert.assertEquals(c1, c2);
+			}
+		}
+		createAndProcessWorld(new TestSystem());
+	}
+
+	@Test
+	public void set_if_exists_should_recycle_existing_component() {
+
+		@Wire(injectInherited = true)
+		class TestSystem extends BasicSystem {
+			@Override
+			protected void process(Entity e) {
+				Pos c1 = mPos.create(e);
+				Pos c2 = mPos.set(e, true);
+				Assert.assertEquals(c1, c2);
+			}
+		}
+		createAndProcessWorld(new TestSystem());
+	}
+
+	@Test
+	public void set_if_exists_should_remove_component() {
+
+		@Wire(injectInherited = true)
+		class TestSystem extends BasicSystem {
+			@Override
+			protected void process(Entity e) {
+				mPos.create(e);
+				mPos.set(e,false);
+				Assert.assertFalse(mPos.has(e));
+			}
+		}
+		createAndProcessWorld(new TestSystem());
+	}
+
+	@Test
+	public void remove_if_exists_should_remove_component() {
+
+		@Wire(injectInherited = true)
+		class TestSystem extends BasicSystem {
+			@Override
+			protected void process(Entity e) {
+				mPos.create(e);
+				mPos.remove(e);
+				Assert.assertFalse(mPos.has(e));
+			}
+		}
+		createAndProcessWorld(new TestSystem());
+	}
+
+	@Test
+	public void remove_if_missing_should_not_explode() {
+
+		@Wire(injectInherited = true)
+		class TestSystem extends BasicSystem {
+			@Override
+			protected void process(Entity e) {
+				mPos.remove(e);
+				Assert.assertFalse(mPos.has(e));
+			}
+		}
+		createAndProcessWorld(new TestSystem());
+	}
+
+	@Test
+	public void set_if_missing_should_not_explode() {
+
+		@Wire(injectInherited = true)
+		class TestSystem extends BasicSystem {
+			@Override
+			protected void process(Entity e) {
+				mPos.set(e, false);
+				Assert.assertFalse(mPos.has(e));
+			}
+		}
+		createAndProcessWorld(new TestSystem());
+	}
+
+	@Test
+	public void getsafe_with_fallback_should_return_fallback_when_component_missing() {
+
+		@Wire(injectInherited = true)
+		class TestSystem extends BasicSystem {
+
+			private Pos fallbackPos = new Pos(10,10);
+
+			@Override
+			protected void process(Entity e) {
+				Assert.assertEquals("expected to return fallback.", fallbackPos, mPos.getSafe(e, fallbackPos));
+			}
+		}
+		createAndProcessWorld(new TestSystem());
+	}
+
+	@Test
+	public void getsafe_with_fallback_should_return_component_when_available() {
+
+		@Wire(injectInherited = true)
+		class TestSystem extends BasicSystem {
+
+			private Pos fallbackPos = new Pos(10,10);
+
+			@Override
+			protected void process(Entity e) {
+				final Pos pos = mPos.create(e);
+				Assert.assertEquals("expected to return component.", pos, mPos.getSafe(e, fallbackPos));
+			}
+		}
+		createAndProcessWorld(new TestSystem());
+	}
+
+	@Test
+	public void getsafe_with_null_fallback_should_return_null() {
+
+		@Wire(injectInherited = true)
+		class TestSystem extends BasicSystem {
+
+			private Pos fallbackPos = new Pos(10,10);
+
+			@Override
+			protected void process(Entity e) {
+				Assert.assertNull(mPos.getSafe(e, null));
+			}
+		}
+		createAndProcessWorld(new TestSystem());
+	}
+
+	protected void createAndProcessWorld(BaseSystem system) {
+		final World world = new World(new WorldConfiguration().setSystem(system));
+		world.createEntity().edit().create(TestMarker.class);
+		world.process();
+	}
+
+	@Test
+	public void create_right_after_entity_creation_should_not_throw_exception() {
+		@Wire(injectInherited = true)
+		class TestSystem extends BasicSystem {
+			@Override
+			protected void process(Entity e) {
+				final Entity t1 = world.createEntity();
+				Pos c1 = mPos.create(t1);
+				Assert.assertNotNull(c1);
+			}
+		}
+		createAndProcessWorld(new TestSystem());
+	}
+
+
+	@Test
+	public void remove_right_after_entity_creation_should_not_throw_exception() {
+		@Wire(injectInherited = true)
+		class TestSystem extends BasicSystem {
+			@Override
+			protected void process(Entity e) {
+				final Entity t1 = world.createEntity();
+				mPos.remove(t1);
+			}
+		}
+		createAndProcessWorld(new TestSystem());
+	}
+
+	@Test
+	public void create_by_id_right_after_entity_creation_should_not_throw_exception() {
+		@Wire(injectInherited = true)
+		class TestSystem extends BasicSystem {
+			@Override
+			protected void process(Entity e) {
+				final Entity t1 = world.createEntity();
+				Pos c1 = mPos.create(t1.id);
+				Assert.assertNotNull(c1);
+			}
+		}
+		createAndProcessWorld(new TestSystem());
+	}
+
+
+	@Test
+	public void remove_by_id_right_after_entity_creation_should_not_throw_exception() {
+		@Wire(injectInherited = true)
+		class TestSystem extends BasicSystem {
+			@Override
+			protected void process(Entity e) {
+				final Entity t1 = world.createEntity();
+				mPos.remove(t1.id);
+			}
+		}
+		createAndProcessWorld(new TestSystem());
+	}
+
+
+}


### PR DESCRIPTION
Feature incubated in contrib. Leads to brevity in code for common mapper patterns.

 Adds to `ComponentMapper`:
- `#create(entity)` Creates component, or returns existing.
- `#remove(entity)` Removes component, does nothing when already removed.
- `#getSafe(entity,passthrough)` Returns component, or passthrough if missing.
- `#set(entity, boolean)` Add/remove component, useful for toggling tag components.

Includes entity id versions as well. Uses [Transmuters](https://github.com/junkdog/artemis-odb/wiki/Entity) behind the scenes.

--

Easily create and remove components, helps you write shorter code.
```java
   if ( !mPhysics.has(e) ) { e.edit().add(Physics.class); } 
   Physics p = mPhysics.get(e);
```
becomes
```java
  Physics p = mPhysics.create(e);
```