### PR TITLE
Port WorldConfigurationBuilder and Plugin API

### DIFF
--- a/artemis-debug/pom.xml
+++ b/artemis-debug/pom.xml
@@ -13,6 +13,15 @@
 	<description>Debug agent, standard library but with more safety checks.</description>
 	<url>https://github.com/junkdog/artemis-odb</url>
 
+	<dependencies>
+		<dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-all</artifactId>
+			<version>1.9.5</version>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
+
 	<build>
 		<sourceDirectory>../artemis/src/main/java</sourceDirectory>
 		<testSourceDirectory>../artemis/src/test/java</testSourceDirectory>

--- a/artemis/pom.xml
+++ b/artemis/pom.xml
@@ -1,35 +1,45 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-	<modelVersion>4.0.0</modelVersion>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
 
-	<parent>
-		<groupId>net.onedaybeard.artemis</groupId>
-		<artifactId>artemis-parent</artifactId>
-		<version>1.0.0-SNAPSHOT</version>
-	</parent>
-	<artifactId>artemis-odb</artifactId>
-	<packaging>jar</packaging>
-	<name>artemis-odb</name>
+    <parent>
+        <groupId>net.onedaybeard.artemis</groupId>
+        <artifactId>artemis-parent</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+    </parent>
+    <artifactId>artemis-odb</artifactId>
+    <packaging>jar</packaging>
+    <name>artemis-odb</name>
 
-	<description>Fork of Artemis Entity System Framework.</description>
-	<url>https://github.com/junkdog/artemis-odb</url>
+    <description>Fork of Artemis Entity System Framework.</description>
+    <url>https://github.com/junkdog/artemis-odb</url>
 
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-source-plugin</artifactId>
-				<version>2.4</version>
-				<executions>
-					<execution>
-						<id>attach-sources</id>
-						<phase>generate-resources</phase>
-						<goals>
-							<goal>jar-no-fork</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
-		</plugins>
-	</build>
+    <dependencies>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-all</artifactId>
+            <version>1.9.5</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <version>2.4</version>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <phase>generate-resources</phase>
+                        <goals>
+                            <goal>jar-no-fork</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 
 </project>

--- a/artemis/src/main/java/com/artemis/ArtemisPlugin.java
+++ b/artemis/src/main/java/com/artemis/ArtemisPlugin.java
@@ -1,0 +1,26 @@
+package com.artemis;
+
+/**
+ * Plugin for artemis-odb.
+ *
+ * @author Daan van Yperen
+ */
+public interface ArtemisPlugin {
+
+	/**
+	 * Register your plugin.
+	 *
+	 * Set up all your dependencies here.
+	 * - systems
+	 * - managers
+	 * - field resolvers
+	 * - other plugins
+	 *
+	 * Always prefer to use {@see WorldConfigurationBuilder#dependsOn} as it can handle repeated dependencies,
+	 * as opposed to {@see WorldConfigurationBuilder#with}, which will throw an exception upon attempting to
+	 * add a pre-existing class.
+	 *
+	 * @param b builder to register your dependencies with.
+	 */
+	void setup(WorldConfigurationBuilder b);
+}

--- a/artemis/src/main/java/com/artemis/ConfigurationElement.java
+++ b/artemis/src/main/java/com/artemis/ConfigurationElement.java
@@ -1,0 +1,57 @@
+package com.artemis;
+
+import java.lang.Class;import java.lang.Comparable;import java.lang.Object;import java.lang.Override;
+
+
+/**
+ * Artemis pieces with priority pending registration.
+ *
+ * @author Daan van Yperen
+ * @see WorldConfigurationBuilder
+ */
+class ConfigurationElement<T> implements Comparable<ConfigurationElement<T>> {
+	public final boolean passive;
+	public final int priority;
+	public final Class<?> itemType;
+	public T item;
+
+	public ConfigurationElement(T item, int priority, boolean passive) {
+		this.item = item;
+		itemType = item.getClass();
+		this.priority = priority;
+		this.passive = passive;
+	}
+
+	@Override
+	public int compareTo(ConfigurationElement<T> o) {
+		// Sort by priority descending.
+		return o.priority - priority;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) return true;
+		if (o == null || getClass() != o.getClass()) return false;
+		return item.equals(((ConfigurationElement<?>) o).item);
+	}
+
+	@Override
+	public int hashCode() {
+		return item.hashCode();
+	}
+
+	/** create instance of Registerable. */
+	public static <T> ConfigurationElement<T> of(T item) {
+		return of(item, WorldConfigurationBuilder.Priority.NORMAL, false);
+	}
+
+	/** create instance of Registerable. */
+	public static <T> ConfigurationElement<T> of(T item, int priority, boolean passive) {
+		return new ConfigurationElement<T>(item, priority, passive);
+	}
+
+	/** create instance of Registerable. */
+	public static <T> ConfigurationElement<T> of(T item, int priority) {
+		return of(item, priority, false);
+	}
+}

--- a/artemis/src/main/java/com/artemis/WorldConfigurationBuilder.java
+++ b/artemis/src/main/java/com/artemis/WorldConfigurationBuilder.java
@@ -1,0 +1,393 @@
+package com.artemis;
+
+import com.artemis.injection.CachedInjector;
+import com.artemis.injection.FieldHandler;
+import com.artemis.injection.FieldResolver;
+import com.artemis.injection.InjectionCache;
+import com.artemis.utils.Bag;
+import com.artemis.utils.Sort;
+import com.artemis.utils.reflect.ClassReflection;
+import com.artemis.utils.reflect.ReflectionException;
+
+/**
+ * World builder.
+ *
+ * @author Daan van Yperen
+ */
+public class WorldConfigurationBuilder {
+	private Bag<ConfigurationElement<? extends Manager>> managers;
+	private Bag<ConfigurationElement<? extends BaseSystem>> systems;
+	private Bag<ConfigurationElement<? extends FieldResolver>> fieldResolvers;
+	private Bag<ConfigurationElement<? extends ArtemisPlugin>> plugins;
+
+	private ArtemisPlugin activePlugin;
+	private final InjectionCache cache;
+	private SystemInvocationStrategy invocationStrategy;
+
+	public WorldConfigurationBuilder() {
+		reset();
+		cache = new InjectionCache();
+	}
+
+	/**
+	 * Assemble world with managers and systems.
+	 * <p/>
+	 * Deprecated: World Configuration
+	 */
+	public WorldConfiguration build() {
+		appendPlugins();
+		final WorldConfiguration config = new WorldConfiguration();
+		registerManagers(config);
+		registerSystems(config);
+		registerFieldResolvers(config);
+		registerInvocationStrategies(config);
+		reset();
+		return config;
+	}
+
+	private void registerInvocationStrategies(WorldConfiguration config) {
+		if (invocationStrategy != null) {
+			config.setInvocationStrategy(invocationStrategy);
+		}
+	}
+
+	/**
+	 * Append plugin configurations.
+	 * Supports plugins registering plugins.
+	 */
+	private void appendPlugins() {
+		int i = 0;
+
+		while (i < plugins.size()) {
+			activePlugin = plugins.get(i).item;
+			activePlugin.setup(this);
+			i++;
+		}
+		activePlugin = null;
+	}
+
+	/**
+	 * add custom field handler with resolvers.
+	 */
+	protected void registerFieldResolvers(WorldConfiguration config) {
+
+		if (fieldResolvers.size() > 0) {
+			Sort.instance().sort(fieldResolvers);
+			// instance default field handler
+			final FieldHandler fieldHandler = new FieldHandler(new InjectionCache());
+
+			for (ConfigurationElement<? extends FieldResolver> configurationElement : fieldResolvers) {
+				fieldHandler.addFieldResolver(configurationElement.item);
+			}
+
+			config.setInjector(new CachedInjector().setFieldHandler(fieldHandler));
+		}
+	}
+
+	/**
+	 * add managers to config.
+	 */
+	private void registerManagers(WorldConfiguration config) {
+		Sort.instance().sort(managers);
+		for (ConfigurationElement<? extends Manager> configurationElement : managers) {
+			config.setManager(configurationElement.item);
+		}
+	}
+
+	/**
+	 * add systems to config.
+	 */
+	private void registerSystems(WorldConfiguration config) {
+		Sort.instance().sort(systems);
+		for (ConfigurationElement<? extends BaseSystem> configurationElement : systems) {
+			config.setSystem(configurationElement.item, configurationElement.passive);
+		}
+	}
+
+	/**
+	 * Reset builder
+	 */
+	private void reset() {
+		invocationStrategy = null;
+		managers = new Bag<ConfigurationElement<? extends Manager>>();
+		systems = new Bag<ConfigurationElement<? extends BaseSystem>>();
+		fieldResolvers = new Bag<ConfigurationElement<? extends FieldResolver>>();
+		plugins = new Bag<ConfigurationElement<? extends ArtemisPlugin>>();
+	}
+
+	/**
+	 * Add field resolver.
+	 *
+	 * @param fieldResolvers
+	 * @return this
+	 */
+	public WorldConfigurationBuilder register(FieldResolver... fieldResolvers) {
+		for (FieldResolver fieldResolver : fieldResolvers) {
+			this.fieldResolvers.add(ConfigurationElement.of(fieldResolver));
+		}
+		return this;
+	}
+
+	/**
+	 * Add system invocation strategy.
+	 *
+	 * @param strategy strategy to invoke.
+	 * @return this
+	 */
+	public WorldConfigurationBuilder register(SystemInvocationStrategy strategy) {
+		this.invocationStrategy = strategy;
+		return this;
+	}
+
+	/**
+	 * Add one or more managers to the world with default priority.
+	 * <p/>
+	 * Managers track priority separate from system priority, and are always added before systems.
+	 * <p/>
+	 * Only one instance of each class is allowed.
+	 * Use {@see #dependsOn} from within plugins whenever possible.
+	 *
+	 * @param managers Managers to add. Will be added in passed order.
+	 * @return this
+	 * @throws WorldConfigurationException if registering the same class twice.
+	 */
+	public WorldConfigurationBuilder with(Manager... managers) {
+		return with(Priority.NORMAL, managers);
+	}
+
+	/**
+	 * Add one or more managers to the world.
+	 * <p/>
+	 * Managers track priority separate from system priority, and are always added before systems.
+	 * <p/>
+	 * Only one instance of each class is allowed.
+	 * Use {@see #dependsOn} from within plugins whenever possible.
+	 *
+	 * @param priority Priority of managers. Higher priority managers are registered before lower priority managers.
+	 * @param managers Managers to add. Will be added in passed order.
+	 * @return this
+	 * @throws WorldConfigurationException if registering the same class twice.
+	 */
+	public WorldConfigurationBuilder with(int priority, Manager... managers) {
+		for (Manager manager : managers) {
+
+			if (containsType(this.managers, manager.getClass())) {
+				throw new WorldConfigurationException("Manager of type " + manager.getClass() + " registered twice. Only once allowed.");
+			}
+
+			this.managers.add(ConfigurationElement.of(manager, priority));
+		}
+		return this;
+	}
+
+	/**
+	 * Specify dependency on managers/systems/plugins.
+	 * <p/>
+	 * Managers track priority separate from system priority, and are always added before systems.
+	 *
+	 * @param types required managers and/or systems.
+	 * @return this
+	 */
+	public final WorldConfigurationBuilder dependsOn(Class... types) {
+		return dependsOn(Priority.NORMAL, types);
+	}
+
+	/**
+	 * Specify dependency on managers/systems/plugins.
+	 * <p/>
+	 * Managers track priority separate from system priority, and are always added before systems.
+	 * Plugins do not support priority.
+	 *
+	 * @param types    required managers and/or systems.
+	 * @param priority Higher priority are registered first. Not supported for plugins.
+	 * @return this
+	 * @throws WorldConfigurationException if unsupported classes are passed or plugins are given a priority.
+	 */
+	@SuppressWarnings("unchecked")
+	public final WorldConfigurationBuilder dependsOn(int priority, Class... types) {
+		for (Class type : types) {
+			try {
+				switch (cache.getFieldClassType(type)) {
+					case SYSTEM:
+						dependsOnSystem(priority, type);
+						break;
+					case MANAGER:
+						dependsOnManager(priority, type);
+						break;
+					default:
+						if (ClassReflection.isAssignableFrom(ArtemisPlugin.class, type)) {
+							if (priority != Priority.NORMAL) {
+								throw new WorldConfigurationException("Priority not supported on plugins.");
+							}
+							dependsOnPlugin(type);
+						} else {
+							throw new WorldConfigurationException("Unsupported type. Only supports managers and systems.");
+						}
+				}
+			} catch (ReflectionException e) {
+				throw new WorldConfigurationException("Unable to instance " + type + " via reflection.", e);
+			}
+		}
+		return this;
+	}
+
+	protected void dependsOnManager(int priority, Class<? extends Manager> type) throws ReflectionException {
+		if (!containsType(managers, type)) {
+			this.managers.add(ConfigurationElement.of(ClassReflection.newInstance(type), priority));
+		}
+	}
+
+	protected void dependsOnSystem(int priority, Class<? extends BaseSystem> type) throws ReflectionException {
+		if (!containsType(systems, type)) {
+			this.systems.add(ConfigurationElement.of(ClassReflection.newInstance(type), priority));
+		}
+	}
+
+	private void dependsOnPlugin(Class<? extends ArtemisPlugin> type) throws ReflectionException {
+		if (!containsType(plugins, type)) {
+			this.plugins.add(ConfigurationElement.of(ClassReflection.newInstance(type)));
+		}
+	}
+
+	/**
+	 * Register active system(s).
+	 * <p/>
+	 * Systems track priority separate from manager priority, and are always added after managers.
+	 * <p/>
+	 * Only one instance of each class is allowed.
+	 * Use {@see #dependsOn} from within plugins whenever possible.
+	 *
+	 * @param systems  systems to add, order is preserved.
+	 * @param priority priority of added systems, higher priority are added before lower priority.
+	 * @return this
+	 * @throws WorldConfigurationException if registering the same class twice.
+	 */
+	public WorldConfigurationBuilder with(int priority, BaseSystem... systems) {
+		addSystems(priority, systems, false);
+		return this;
+	}
+
+	/**
+	 * Register active system(s).
+	 * <p/>
+	 * Systems track priority separate from manager priority, and are always added after managers.
+	 * <p/>
+	 * Only one instance of each class is allowed.
+	 * Use {@see #dependsOn} from within plugins whenever possible.
+	 *
+	 * @param systems systems to add, order is preserved.
+	 * @return this
+	 * @throws WorldConfigurationException if registering the same class twice.
+	 */
+	public WorldConfigurationBuilder with(BaseSystem... systems) {
+		addSystems(Priority.NORMAL, systems, false);
+		return this;
+	}
+
+
+	/**
+	 * Add plugins to world.
+	 * <p/>
+	 * Upon build plugins will be called to register dependencies.
+	 * <p/>
+	 * Only one instance of each class is allowed.
+	 * Use {@see #dependsOn} from within plugins whenever possible.
+	 *
+	 * @param plugins Plugins to add.
+	 * @return this
+	 * @throws WorldConfigurationException if type is added more than once.
+	 */
+	public WorldConfigurationBuilder with(ArtemisPlugin... plugins) {
+		addPlugins(plugins);
+		return this;
+	}
+
+	/**
+	 * Register passive systems.
+	 * <p/>
+	 * Systems track priority separate from manager priority, and are always added after managers.
+	 * <p/>
+	 * Only one instance of each class is allowed.
+	 * Use {@see #dependsOn} from within plugins.
+	 *
+	 * @param systems  systems to add, order is preserved.
+	 * @param priority priority of added systems, higher priority are added before lower priority.
+	 * @return this
+	 * @throws WorldConfigurationException if type is added more than once.
+	 */
+	public WorldConfigurationBuilder withPassive(int priority, BaseSystem... systems) {
+		addSystems(priority, systems, true);
+		return this;
+	}
+
+	/**
+	 * Register passive systems with normal priority.
+	 * <p/>
+	 * Systems track priority separate from manager priority, and are always added after managers.
+	 * <p/>
+	 * Only one instance of each class is allowed.
+	 * Use {@see #dependsOn} from within plugins whenever possible.
+	 *
+	 * @param systems systems to add, order is preserved.
+	 * @return this
+	 * @throws WorldConfigurationException if type is added more than once.
+	 */
+	public WorldConfigurationBuilder withPassive(BaseSystem... systems) {
+		addSystems(Priority.NORMAL, systems, true);
+		return this;
+	}
+
+	/**
+	 * helper to queue systems for registration.
+	 */
+	private void addSystems(int priority, BaseSystem[] systems, boolean passive) {
+		for (BaseSystem system : systems) {
+
+			if (containsType(this.systems, system.getClass())) {
+				throw new WorldConfigurationException("System of type " + system.getClass() + " registered twice. Only once allowed.");
+			}
+
+			this.systems.add(new ConfigurationElement<BaseSystem>(system, priority, passive));
+		}
+	}
+
+	/**
+	 * Check if bag of registerables contains any of passed type.
+	 *
+	 * @param items bag of registerables.
+	 * @param type  type to check for.
+	 * @return {@code true} if found {@code false} if none.
+	 */
+	@SuppressWarnings("unchecked")
+	private boolean containsType(Bag items, Class type) {
+		for (ConfigurationElement<?> registration : (Bag<ConfigurationElement<?>>) items) {
+			if (registration.itemType == type) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	/**
+	 * Add new plugins.
+	 */
+	private void addPlugins(ArtemisPlugin[] plugins) {
+		for (ArtemisPlugin plugin : plugins) {
+
+			if (containsType(this.plugins, plugin.getClass())) {
+				throw new WorldConfigurationException("Plugin of type " + plugin.getClass() + " registered twice. Only once allowed.");
+			}
+
+			this.plugins.add(ConfigurationElement.of(plugin));
+		}
+	}
+
+	public static abstract class Priority {
+		public static final int LOWEST = Integer.MIN_VALUE;
+		public static final int LOW = -10000;
+		public static final int OPERATIONS = -1000;
+		public static final int NORMAL = 0;
+		public static final int HIGH = 10000;
+		public static final int HIGHEST = Integer.MAX_VALUE;
+	}
+}

--- a/artemis/src/main/java/com/artemis/WorldConfigurationException.java
+++ b/artemis/src/main/java/com/artemis/WorldConfigurationException.java
@@ -1,0 +1,16 @@
+package com.artemis;
+
+import java.lang.RuntimeException;import java.lang.String;import java.lang.Throwable; /**
+ * World configuration failed.
+ *
+ * @author Daan van Yperen
+ */
+public class WorldConfigurationException extends RuntimeException {
+	public WorldConfigurationException(String msg) {
+		super(msg);
+	}
+
+	public WorldConfigurationException(String msg, Throwable e) {
+		super(msg,e);
+	}
+}

--- a/artemis/src/test/java/com/artemis/WorldConfigurationBuilderManagerTest.java
+++ b/artemis/src/test/java/com/artemis/WorldConfigurationBuilderManagerTest.java
@@ -1,0 +1,92 @@
+package com.artemis;
+
+import com.artemis.common.TestEntityManagerA;
+import com.artemis.common.TestEntityManagerB;
+import com.artemis.common.TestEntityManagerC;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;import java.lang.Exception;import java.lang.Override;
+
+/**
+ * @author Daan van Yperen
+ */
+public class WorldConfigurationBuilderManagerTest {
+
+	private WorldConfigurationBuilder builder;
+
+	@Before
+	public void setUp() throws Exception {
+		builder = new WorldConfigurationBuilder();
+	}
+
+	@Test(expected = WorldConfigurationException.class)
+	public void should_refuse_duplicate_managers() {
+		builder.with(new TestEntityManagerA(), new TestEntityManagerB(), new TestEntityManagerA()).build();
+	}
+
+	@Test
+	public void should_support_multiple_plugins_with_same_manager_dependencies() {
+		class SharedDependencyPlugin implements ArtemisPlugin {
+			@Override
+			public void setup(WorldConfigurationBuilder b) {
+				builder.dependsOn(TestEntityManagerA.class);
+			}
+		}
+		class SharedDependencyPluginB extends SharedDependencyPlugin {}
+
+		final World world = new World(builder.with(new SharedDependencyPlugin(), new SharedDependencyPluginB()).build());
+		Assert.assertNotNull(world.getManager(TestEntityManagerA.class));
+	}
+
+	@Test
+	public void should_register_managers_by_priority() {
+		Manager manager1 = new TestEntityManagerA();
+		Manager manager2 = new TestEntityManagerB();
+
+		final World world = new World(new WorldConfigurationBuilder()
+				.with(WorldConfigurationBuilder.Priority.NORMAL, manager1)
+				.with(WorldConfigurationBuilder.Priority.HIGHEST, manager2).build());
+
+		Assert.assertEquals("Expected manager to be loaded by priority.", manager1, getLastLoadedManager(world));
+	}
+
+	@Test
+	public void should_register_dependency_managers_by_priority() {
+
+		final World world = new World(new WorldConfigurationBuilder()
+				.dependsOn(WorldConfigurationBuilder.Priority.NORMAL, TestEntityManagerA.class)
+				.dependsOn(WorldConfigurationBuilder.Priority.HIGHEST, TestEntityManagerB.class).build());
+
+		Assert.assertEquals("Expected manager to be loaded by priority.", TestEntityManagerA.class, getLastLoadedManager(world).getClass());
+	}
+
+	@Test
+	public void should_preserve_order_registering_managers_with_same_priority() {
+
+		final World world = new World(new WorldConfigurationBuilder()
+				.dependsOn(WorldConfigurationBuilder.Priority.NORMAL, TestEntityManagerA.class, TestEntityManagerC.class)
+				.dependsOn(WorldConfigurationBuilder.Priority.HIGHEST, TestEntityManagerB.class).build());
+
+		Assert.assertEquals("Expected manager to be loaded by priority.", TestEntityManagerC.class, getLastLoadedManager(world).getClass());
+	}
+
+	protected Manager getLastLoadedManager(World world) {
+		return world.getManagers().get(world.getManagers().size()-1);
+	}
+
+
+	@Test
+	public void should_create_managers_on_build() {
+		Manager manager1 = new TestEntityManagerA();
+		Manager manager2 = new TestEntityManagerB();
+
+		WorldConfiguration config = new WorldConfigurationBuilder()
+				.with(manager1, manager2).build();
+
+		World world = new World(config);
+
+		Assert.assertTrue(world.getManagers().contains(manager1));
+		Assert.assertTrue(world.getManagers().contains(manager2));
+	}
+
+}

--- a/artemis/src/test/java/com/artemis/WorldConfigurationBuilderPluginTest.java
+++ b/artemis/src/test/java/com/artemis/WorldConfigurationBuilderPluginTest.java
@@ -1,0 +1,91 @@
+package com.artemis;
+
+import com.artemis.common.TestEntitySystemA;
+import com.artemis.common.TestPluginA;
+import com.artemis.common.TestPluginBDependentOnA;
+import com.artemis.common.TestPluginCDependentOnA;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+/**
+ * @author Daan van Yperen
+ */
+public class WorldConfigurationBuilderPluginTest {
+
+	private WorldConfigurationBuilder builder;
+	private ArtemisPlugin plugin;
+
+	@Before
+	public void setUp() throws Exception {
+		builder = new WorldConfigurationBuilder();
+		plugin = mock(ArtemisPlugin.class);
+	}
+
+
+	@Test
+	public void should_register_plugins() {
+		builder.with(plugin).build();
+		verify(plugin).setup(any(WorldConfigurationBuilder.class));
+	}
+
+
+	@Test
+	public void should_register_last_minute_nested_plugins() {
+
+		final ArtemisPlugin parentPlugin = new ArtemisPlugin() {
+			@Override
+			public void setup(WorldConfigurationBuilder b) {
+				b.with(plugin);
+			}
+		};
+
+		builder.with(parentPlugin).build();
+
+		verify(plugin).setup(any(WorldConfigurationBuilder.class));
+	}
+
+	@Test(expected = WorldConfigurationException.class)
+	public void should_ignore_double_plugins() {
+
+		final ArtemisPlugin parentPlugin = new ArtemisPlugin() {
+			@Override
+			public void setup(WorldConfigurationBuilder b) {
+				b.with(plugin, plugin);
+				b.with(plugin);
+			}
+		};
+
+		builder.with(parentPlugin).build();
+	}
+
+	@Test
+	public void should_register_plugins_by_class() {
+		builder.dependsOn(TestPluginA.class).build();
+	}
+
+	@Test
+	public void should_support_multiple_dependencies_on_plugin() {
+		builder.dependsOn(TestPluginBDependentOnA.class, TestPluginCDependentOnA.class).build();
+	}
+
+	@Test(expected = WorldConfigurationException.class)
+	public void should_refuse_plugins_with_priority() {
+		builder.dependsOn(WorldConfigurationBuilder.Priority.HIGH, TestEntitySystemA.class,TestPluginBDependentOnA.class).build();
+	}
+
+	@Test(expected = WorldConfigurationException.class)
+	public void should_avoid_cyclic_dependencies() {
+		final ArtemisPlugin parentPlugin = new ArtemisPlugin() {
+			@Override
+			public void setup(WorldConfigurationBuilder b) {
+				b.with(this);
+			}
+		};
+		builder.with(parentPlugin).build();
+		// will get stuck in loop if failed.
+	}
+}

--- a/artemis/src/test/java/com/artemis/WorldConfigurationBuilderSystemTest.java
+++ b/artemis/src/test/java/com/artemis/WorldConfigurationBuilderSystemTest.java
@@ -1,0 +1,116 @@
+package com.artemis;
+
+import com.artemis.common.TestEntitySystemA;
+import com.artemis.common.TestEntitySystemB;
+import com.artemis.common.TestEntitySystemC;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * @author Daan van Yperen
+ */
+public class WorldConfigurationBuilderSystemTest {
+
+	private WorldConfigurationBuilder builder;
+
+	@Before
+	public void setUp() throws Exception {
+		builder = new WorldConfigurationBuilder();
+	}
+
+	@Test(expected = WorldConfigurationException.class)
+	public void should_refuse_duplicate_ystems() {
+		builder.with(new TestEntitySystemA(), new TestEntitySystemB(), new TestEntitySystemA()).build();
+	}
+
+	@Test
+	public void should_create_systems_in_order() {
+		BaseSystem system1 = new TestEntitySystemA();
+		BaseSystem system2 = new TestEntitySystemB();
+		BaseSystem system3 = new TestEntitySystemC();
+
+		World world = new World(new WorldConfigurationBuilder()
+				.with(system1, system2)
+				.with(system3).build());
+
+		Assert.assertEquals(system1, world.getSystems().get(0));
+		Assert.assertEquals(system2, world.getSystems().get(1));
+		Assert.assertEquals(system3, world.getSystems().get(2));
+	}
+
+	@Test
+	public void should_add_systems_as_active_by_default() {
+		World world = new World(new WorldConfigurationBuilder()
+				.with(new TestEntitySystemA()).build());
+
+		Assert.assertFalse(world.getSystems().get(0).isPassive());
+	}
+
+	@Test
+	public void should_add_passive_systems_as_passive() {
+		World world =  new World(new WorldConfigurationBuilder()
+				.withPassive(new TestEntitySystemA()).build());
+
+		Assert.assertTrue(world.getSystems().get(0).isPassive());
+	}
+
+	@Test
+	public void should_not_carry_over_old_systems_to_new_world() {
+		WorldConfigurationBuilder builder = new WorldConfigurationBuilder();
+		World world1 = new World(builder.withPassive(new TestEntitySystemA()).build());
+		World world2 = new World(builder.build());
+		Assert.assertEquals(0, world2.getSystems().size());
+	}
+
+	@Test
+	public void should_support_multiple_plugins_with_same_system_dependencies() {
+		class SharedDependencyPlugin implements ArtemisPlugin {
+			@Override
+			public void setup(WorldConfigurationBuilder b) {
+				builder.dependsOn(TestEntitySystemA.class);
+			}
+		}
+		class SharedDependencyPluginB extends SharedDependencyPlugin {}
+
+		final World world = new World(builder.with(new SharedDependencyPlugin(), new SharedDependencyPluginB()).build());
+		Assert.assertNotNull(world.getSystem(TestEntitySystemA.class));
+	}
+
+	@Test
+	public void should_register_systems_by_priority() {
+		BaseSystem system1 = new TestEntitySystemA();
+		BaseSystem system2 = new TestEntitySystemB();
+
+		final World world = new World(new WorldConfigurationBuilder()
+				.with(WorldConfigurationBuilder.Priority.NORMAL, system1)
+				.with(WorldConfigurationBuilder.Priority.HIGHEST, system2).build());
+
+		Assert.assertEquals("Expected system to be loaded by priority.", system1, getLastLoadedSystem(world));
+	}
+
+	@Test
+	public void should_register_dependency_systems_by_priority() {
+
+		final World world = new World(new WorldConfigurationBuilder()
+				.dependsOn(WorldConfigurationBuilder.Priority.NORMAL, TestEntitySystemA.class)
+				.dependsOn(WorldConfigurationBuilder.Priority.HIGHEST, TestEntitySystemB.class).build());
+
+		Assert.assertEquals("Expected system to be loaded by priority.", TestEntitySystemA.class, getLastLoadedSystem(world).getClass());
+	}
+
+	@Test
+	public void should_preserve_system_order_within_same_priority() {
+
+		final World world = new World(new WorldConfigurationBuilder()
+				.dependsOn(WorldConfigurationBuilder.Priority.NORMAL, TestEntitySystemA.class, TestEntitySystemC.class)
+				.dependsOn(WorldConfigurationBuilder.Priority.HIGHEST, TestEntitySystemB.class).build());
+
+		Assert.assertEquals("Expected system to be loaded by priority.", TestEntitySystemC.class, getLastLoadedSystem(world).getClass());
+	}
+
+	private BaseSystem getLastLoadedSystem(World world) {
+		return world.getSystems().get(world.getSystems().size()-1);
+	}
+
+}

--- a/artemis/src/test/java/com/artemis/common/TestEntityManagerA.java
+++ b/artemis/src/test/java/com/artemis/common/TestEntityManagerA.java
@@ -1,0 +1,9 @@
+package com.artemis.common;
+
+import com.artemis.Manager;
+
+/**
+ * @author Daan van Yperen
+ */
+public final class TestEntityManagerA extends Manager {
+}

--- a/artemis/src/test/java/com/artemis/common/TestEntityManagerB.java
+++ b/artemis/src/test/java/com/artemis/common/TestEntityManagerB.java
@@ -1,0 +1,9 @@
+package com.artemis.common;
+
+import com.artemis.Manager;
+
+/**
+ * @author Daan van Yperen
+ */
+public final class TestEntityManagerB extends Manager {
+}

--- a/artemis/src/test/java/com/artemis/common/TestEntityManagerC.java
+++ b/artemis/src/test/java/com/artemis/common/TestEntityManagerC.java
@@ -1,0 +1,9 @@
+package com.artemis.common;
+
+import com.artemis.Manager;
+
+/**
+ * @author Daan van Yperen
+ */
+public final class TestEntityManagerC extends Manager {
+}

--- a/artemis/src/test/java/com/artemis/common/TestEntitySystemA.java
+++ b/artemis/src/test/java/com/artemis/common/TestEntitySystemA.java
@@ -1,0 +1,12 @@
+package com.artemis.common;
+
+import com.artemis.BaseSystem;
+
+/**
+ * @author Daan van Yperen
+ */
+public final class TestEntitySystemA extends BaseSystem {
+	@Override
+	protected void processSystem() {
+	}
+}

--- a/artemis/src/test/java/com/artemis/common/TestEntitySystemB.java
+++ b/artemis/src/test/java/com/artemis/common/TestEntitySystemB.java
@@ -1,0 +1,12 @@
+package com.artemis.common;
+
+import com.artemis.BaseSystem;
+
+/**
+ * @author Daan van Yperen
+ */
+public final class TestEntitySystemB extends BaseSystem {
+	@Override
+	protected void processSystem() {
+	}
+}

--- a/artemis/src/test/java/com/artemis/common/TestEntitySystemC.java
+++ b/artemis/src/test/java/com/artemis/common/TestEntitySystemC.java
@@ -1,0 +1,12 @@
+package com.artemis.common;
+
+import com.artemis.BaseSystem;
+
+/**
+ * @author Daan van Yperen
+ */
+public final class TestEntitySystemC extends BaseSystem {
+	@Override
+	protected void processSystem() {
+	}
+}

--- a/artemis/src/test/java/com/artemis/common/TestPluginA.java
+++ b/artemis/src/test/java/com/artemis/common/TestPluginA.java
@@ -1,0 +1,13 @@
+package com.artemis.common;
+
+import com.artemis.ArtemisPlugin;
+import com.artemis.WorldConfigurationBuilder;
+
+/**
+ * @author Daan van Yperen
+ */
+public class TestPluginA implements ArtemisPlugin {
+	@Override
+	public void setup(WorldConfigurationBuilder b) {
+	}
+}

--- a/artemis/src/test/java/com/artemis/common/TestPluginBDependentOnA.java
+++ b/artemis/src/test/java/com/artemis/common/TestPluginBDependentOnA.java
@@ -1,0 +1,15 @@
+package com.artemis.common;
+
+import com.artemis.ArtemisPlugin;
+import com.artemis.WorldConfigurationBuilder;
+import com.artemis.common.TestPluginA;
+
+/**
+ * @author Daan van Yperen
+ */
+public class TestPluginBDependentOnA implements ArtemisPlugin {
+	@Override
+	public void setup(WorldConfigurationBuilder b) {
+		b.dependsOn(TestPluginA.class);
+	}
+}

--- a/artemis/src/test/java/com/artemis/common/TestPluginCDependentOnA.java
+++ b/artemis/src/test/java/com/artemis/common/TestPluginCDependentOnA.java
@@ -1,0 +1,14 @@
+package com.artemis.common;
+
+import com.artemis.ArtemisPlugin;
+import com.artemis.WorldConfigurationBuilder;
+
+/**
+ * @author Daan van Yperen
+ */
+public class TestPluginCDependentOnA implements ArtemisPlugin {
+	@Override
+	public void setup(WorldConfigurationBuilder b) {
+		b.dependsOn(TestPluginA.class);
+	}
+}


### PR DESCRIPTION
Ports features incubated on contrib: WorldConfigurationBuilder and Plugin API.

@junkdog There's room for improvement in the implementation of priority, perhaps flipping the order makes sense, perhaps we need to expand on the example priority levels.
@gjroelofs Plugin API might be useful for DSL plugin, if configuration is required, or expect some pivots along the road that you want to blackbox for the user. It's pretty young API so feel free to PR as needed.

## Configuration builder

### Why

Convenience var-arg addition of systems, managers. Supports [[plugins|Plugin]].

### Usage

```java
WorldConfiguration config = new WorldConfigurationBuilder()
   .with( new MyManagerA(), new MyManagerB()  ) 
   .with( new MySystemA(), new MySystemB(), new MySystemN()  )
   .with( new MyPluginA(), new MyPluginB(), new MyPluginN()  )
   .register( new MyDIResolver())
   .build();
```

### Order

Order of addition is preserved, but can be overridden.<br/>
This is especially useful for writing [[plugins|Plugin]].

```java
  .with( WorldConfigurationBuilder.Priority.HIGH + 1, new MyPluginA())
```

Artemis-odb calls systems and managers from highest to lowest priority.<br/> 
Default priority is `NORMAL`.

## Plugin API

Packages your artemis-odb extensions as a drop in plugin!

### Why

- Users can add your odb extension with a single line of code. 
- Allows other plugin developers to build upon your extension.
- Avoids dependency clashes with other extensions.
- Inject systems/managers before/after others.

### How?

Implement `ArtemisPlugin`. Register dependencies via `WorldConfigurationBuilder`.

### Special note about Dependencies

When adding plugin dependencies, use `WorldConfigurationBuilder#dependsOn` instead of `#wire`. `#DependsOn` ensures dependencies that already exist are not instanced twice. The game itself is not required to use `#DependsOn` as non plugin systems/managers will be instanced before any plugins.

see [[WorldConfigurationBuilder]] for all options.

### Example

```java
public class MyPlugin implements ArtemisPlugin {

    @Override
    public void setup(WorldConfigurationBuilder b) {

        // hook plugins.
        b.dependsOn(ExtendedComponentMapperPlugin.class);

        // hook managers or systems.
        b.dependsOn(TagManager.class, GroupManager.class);
        b.dependsOn(MySystemA.class, MySystemB.class);

        // Optionally Specify loading order.
        b.with(WorldConfigurationBuilder.Priority.HIGH, new LoadFirstSystem());

        // And your custom DI features!
        b.register(new MyFieldResolver());
    }
}
```

### Using

```java
  WorldConfiguration myConfig = new WorldConfigurationBuilder()
                .with(new TagManager())
                .with(new MyGameSystemA(), new MyGameSystemB())
                .with(new MyPlugin())
                .build();
```