### PR TITLE
Hotfix #413

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 ## Change Log (we do our best to adhere to [semantic versioning](http://semver.org/))
 
 #### Version: 1.4.0-SNAPSHOT
+- **BREAKING CHANGES**
+  - If you have overridden default injection functionality and instance FieldHandler
+    yourself, be aware the FieldHandler constructor behaviour has changed.
+
+- **Fix**: Using custom FieldHandler or FieldResolver disabled @Wire on fields.
+  - Warn if attempting to inject custom objects without prerequisite resolver (PojoFieldResolver).
 
 #### Version: 1.3.1 - 2015-12-29
 - **Fix**: During deserialization, indirectly referenced entities were not included in

--- a/artemis-gwt-test/pom.xml
+++ b/artemis-gwt-test/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>net.onedaybeard.artemis</groupId>
 		<artifactId>artemis-parent</artifactId>
-		<version>1.3.0-SNAPSHOT</version>
+		<version>1.4.0-SNAPSHOT</version>
 	</parent>
 	<description>Integration tests for gwt.</description>
 	<artifactId>artemis-odb-gwt-test</artifactId>

--- a/artemis-gwt/src/main/resources/com/artemis/gwtref/ArtemisReflect.gwt.xml
+++ b/artemis-gwt/src/main/resources/com/artemis/gwtref/ArtemisReflect.gwt.xml
@@ -50,6 +50,7 @@
     <extend-configuration-property name="artemis.reflect.include" value="com.artemis.injection.UseInjectionCache"/>
     <extend-configuration-property name="artemis.reflect.include" value="com.artemis.injection.ArtemisFieldResolver"/>
     <extend-configuration-property name="artemis.reflect.include" value="com.artemis.injection.WiredFieldResolver"/>
+    <extend-configuration-property name="artemis.reflect.include" value="com.artemis.injection.PojoFieldResolver"/>
 
     <source path="">
         <exclude name="**/gen/**"/>

--- a/artemis/src/main/java/com/artemis/InjectionException.java
+++ b/artemis/src/main/java/com/artemis/InjectionException.java
@@ -1,0 +1,16 @@
+package com.artemis;
+
+/**
+ * Injection failed.
+ *
+ * @author Daan van Yperen
+ */
+public class InjectionException extends RuntimeException {
+	public InjectionException(String msg) {
+		super(msg);
+	}
+
+	public InjectionException(String msg, Throwable e) {
+		super(msg,e);
+	}
+}

--- a/artemis/src/main/java/com/artemis/injection/CachedInjector.java
+++ b/artemis/src/main/java/com/artemis/injection/CachedInjector.java
@@ -37,9 +37,10 @@ public final class CachedInjector implements Injector {
 	@Override
 	public void initialize(World world, Map<String, Object> injectables) {
 		if (fieldHandler == null) {
-			fieldHandler = new FieldHandler(cache, injectables);
+			fieldHandler = new FieldHandler(cache);
 		}
-		fieldHandler.initialize(world);
+
+		fieldHandler.initialize(world, injectables);
 	}
 
 	@Override

--- a/artemis/src/main/java/com/artemis/injection/FieldHandler.java
+++ b/artemis/src/main/java/com/artemis/injection/FieldHandler.java
@@ -96,7 +96,7 @@ public class FieldHandler {
 			fieldResolver.initialize(world);
 		}
 
-		if ( !fieldResolverFound )
+		if ( injectables != null && !injectables.isEmpty() && !fieldResolverFound )
 		{
 			throw new InjectionException("FieldHandler lacks resolver capable of dealing with your custom injectables. Register a WiredFieldResolver or PojoFieldResolver with your FieldHandler.");
 		}

--- a/artemis/src/main/java/com/artemis/injection/Injector.java
+++ b/artemis/src/main/java/com/artemis/injection/Injector.java
@@ -1,5 +1,6 @@
 package com.artemis.injection;
 
+import com.artemis.InjectionException;
 import com.artemis.World;
 
 import java.util.Map;
@@ -21,6 +22,7 @@ public interface Injector {
 	/**
 	 * @param world       this Injector will be used for
 	 * @param injectables registered via {@link com.artemis.WorldConfiguration#register}
+	 * @throws InjectionException when injector lacks a means to inject injectables.
 	 */
 	void initialize(World world, Map<String, Object> injectables);
 

--- a/artemis/src/main/java/com/artemis/injection/PojoFieldResolver.java
+++ b/artemis/src/main/java/com/artemis/injection/PojoFieldResolver.java
@@ -1,0 +1,18 @@
+package com.artemis.injection;
+
+import java.util.Map;
+
+/**
+ * Field resolver for manually registered objects, for injection by type or name.
+ *
+ * @see com.artemis.WorldConfiguration#register
+ * @author Daan van Yperen
+ */
+public interface PojoFieldResolver extends FieldResolver {
+
+	/**
+	 * Set manaully registered objects.
+	 * @param pojos Map of manually registered objects.
+	 */
+	void setPojos(Map<String, Object> pojos);
+}

--- a/artemis/src/main/java/com/artemis/injection/WiredFieldResolver.java
+++ b/artemis/src/main/java/com/artemis/injection/WiredFieldResolver.java
@@ -4,6 +4,7 @@ import com.artemis.MundaneWireException;
 import com.artemis.World;
 import com.artemis.utils.reflect.Field;
 
+import java.util.HashMap;
 import java.util.Map;
 
 import static java.lang.String.format;
@@ -14,13 +15,12 @@ import static java.lang.String.format;
  *
  * @author Snorre E. Brekke
  */
-public class WiredFieldResolver implements FieldResolver, UseInjectionCache {
+public class WiredFieldResolver implements UseInjectionCache, PojoFieldResolver {
 	private InjectionCache cache;
 
-	private Map<String, Object> pojos;
+	private Map<String, Object> pojos = new HashMap<String, Object>();
 
-	public WiredFieldResolver(Map<String, Object> pojos) {
-		this.pojos = pojos;
+	public WiredFieldResolver() {
 	}
 
 	@Override
@@ -52,5 +52,10 @@ public class WiredFieldResolver implements FieldResolver, UseInjectionCache {
 	@Override
 	public void setCache(InjectionCache cache) {
 		this.cache = cache;
+	}
+
+	@Override
+	public void setPojos(Map<String, Object> pojos) {
+		this.pojos = pojos;
 	}
 }

--- a/artemis/src/test/java/com/artemis/FieldHandlerTest.java
+++ b/artemis/src/test/java/com/artemis/FieldHandlerTest.java
@@ -1,16 +1,16 @@
 package com.artemis;
 
 import com.artemis.annotations.Wire;
-import com.artemis.injection.CachedInjector;
-import com.artemis.injection.FieldHandler;
-import com.artemis.injection.FieldResolver;
-import com.artemis.injection.InjectionCache;
-import com.artemis.injection.Injector;
+import com.artemis.injection.*;
+import com.artemis.utils.Bag;
 import com.artemis.utils.reflect.ClassReflection;
 import com.artemis.utils.reflect.Field;
 import com.artemis.utils.reflect.ReflectionException;
 import org.junit.Test;
 
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 
@@ -35,28 +35,6 @@ public class FieldHandlerTest {
         assertNotNull(withCoreFields.manager);
         assertNotNull(withCoreFields.injectedObject);
 
-        assertNull(withCoreFields.notInjected);
-    }
-
-    @Test
-    public void custom_field_handler_should_not_inject_wire_fields() throws Exception {
-        FieldHandler fieldHandler = new FieldHandler(new InjectionCache());
-        Injector injector = new CachedInjector().setFieldHandler(fieldHandler);
-        WorldConfiguration worldConfiguration = new WorldConfiguration()
-                .setInjector(injector)
-                .setSystem(new SomeSystem())
-                .setSystem(new SomeManager())
-                .register(new Object());
-        World world = new World(worldConfiguration);
-
-        ObjectWithCoreFields withCoreFields = new ObjectWithCoreFields();
-        world.inject(withCoreFields);
-
-        assertNotNull(withCoreFields.cm);
-        assertNotNull(withCoreFields.system);
-        assertNotNull(withCoreFields.manager);
-
-        assertNull(withCoreFields.injectedObject);
         assertNull(withCoreFields.notInjected);
     }
 

--- a/artemis/src/test/java/com/artemis/PojoFieldResolverTest.java
+++ b/artemis/src/test/java/com/artemis/PojoFieldResolverTest.java
@@ -25,6 +25,13 @@ public class PojoFieldResolverTest {
 	}
 
 	@Test
+	public void custom_field_handler_without_field_resolver_should_not_fail_if_no_injectables() {
+		WorldConfiguration configuration =
+				new WorldConfiguration().setInjector(createInjectorWithCustomHandler());
+		new World(configuration);
+	}
+
+	@Test
 	public void pojo_field_resolver_should_be_supplied_with_any_injectables() {
 		PojoFieldResolverImpl pojoFieldResolver = new PojoFieldResolverImpl();
 		WorldConfiguration configuration =

--- a/artemis/src/test/java/com/artemis/PojoFieldResolverTest.java
+++ b/artemis/src/test/java/com/artemis/PojoFieldResolverTest.java
@@ -1,0 +1,82 @@
+package com.artemis;
+
+import com.artemis.injection.*;
+import com.artemis.utils.Bag;
+import com.artemis.utils.reflect.Field;
+import org.junit.Test;
+
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author Daan van Yperen
+ */
+public class PojoFieldResolverTest {
+
+	@Test(expected = InjectionException.class)
+	public void custom_field_handler_without_field_resolver_should_fail_if_any_injectables() {
+
+		WorldConfiguration configuration =
+				new WorldConfiguration().setInjector(createInjectorWithCustomHandler());
+		configuration.register(new BlankObject());
+
+		new World(configuration);
+	}
+
+	@Test
+	public void pojo_field_resolver_should_be_supplied_with_any_injectables() {
+		PojoFieldResolverImpl pojoFieldResolver = new PojoFieldResolverImpl();
+		WorldConfiguration configuration =
+				new WorldConfiguration().setInjector(createInjectorWithCustomHandler(pojoFieldResolver));
+		configuration.register("a",new BlankObject());
+		configuration.register("b",new BlankObject());
+		new World(configuration);
+		assertEquals(2, pojoFieldResolver.pojos.size());
+	}
+
+	private Injector createInjectorWithCustomHandler(FieldResolver... resolvers ) {
+		Injector myInjector = new CachedInjector();
+
+		Bag<FieldResolver> resolverBag = new Bag<FieldResolver>(resolvers.length);
+		for (FieldResolver resolver : resolvers) {
+			resolverBag.add(resolver);
+		}
+
+		FieldHandler handler = new FieldHandler(new InjectionCache(), resolverBag);
+		for (FieldResolver resolver : resolvers) {
+			handler.addFieldResolver(resolver);
+		}
+		myInjector.setFieldHandler(handler);
+
+		return myInjector;
+	}
+
+
+	private static class PojoFieldResolverImpl implements PojoFieldResolver {
+
+		private Map<String, Object> pojos;
+
+		public Map<String, Object> getPojos() {
+			return pojos;
+		}
+
+		@Override
+		public void setPojos(Map<String, Object> pojos) {
+			this.pojos = pojos;
+		}
+
+		@Override
+		public void initialize(World world) {
+
+		}
+
+		@Override
+		public Object resolve(Class<?> fieldType, Field field) {
+			return null;
+		}
+	}
+
+	public static class BlankObject {
+	}
+}

--- a/artemis/src/test/java/com/artemis/WorldConfigurationBuilderInjectionTest.java
+++ b/artemis/src/test/java/com/artemis/WorldConfigurationBuilderInjectionTest.java
@@ -1,0 +1,56 @@
+package com.artemis;
+
+import com.artemis.annotations.Wire;
+import com.artemis.injection.FieldResolver;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+/**
+ * @author Daan van Yperen
+ */
+public class WorldConfigurationBuilderInjectionTest {
+
+	private WorldConfigurationBuilder builder;
+
+	@Before
+	public void setUp() throws Exception {
+		builder = new WorldConfigurationBuilder();
+	}
+
+	@Test
+	public void custom_field_resolvers_should_not_suppress_default_wiring() {
+
+		FieldResolver resolver = mock(FieldResolver.class);
+		CoopSystem coopSystem = new CoopSystem();
+		builder
+				.with(coopSystem)
+				.register(resolver);
+
+		WorldConfiguration configuration = builder.build();
+		Chicken chicken = new Chicken();
+		configuration.register(chicken);
+
+		new World(configuration);
+		assertEquals(chicken,coopSystem.myChicken);
+		assertNotNull(coopSystem.mFlaming);
+	}
+
+	public static class Chicken {};
+	public static class Flaming extends Component {};
+	public static class CoopSystem extends BaseSystem {
+
+		@Wire
+		public Chicken myChicken;
+		public ComponentMapper<Flaming> mFlaming;
+
+		@Override
+		protected void processSystem() {
+		}
+	}
+}


### PR DESCRIPTION
**BREAKING CHANGES**
  - If you have overridden default injection functionality and instance FieldHandler
    yourself, be aware the FieldHandler constructor behaviour has changed.

- **Fix**: Using custom FieldHandler or FieldResolver disabled @Wire on fields.
  - Warn if attempting to inject custom objects without prerequisite resolver (PojoFieldResolver).
  
Solves #413