### PR TITLE
Fix #449: Remove deprecated `WorldConfigurationBuilder#withPassive`.

### DIFF
--- a/artemis/src/main/java/com/artemis/World.java
+++ b/artemis/src/main/java/com/artemis/World.java
@@ -375,7 +375,7 @@ public class World {
 	}
 
 	/**
-	 * Process all non-passive systems.
+	 * Process all systems.
 	 * @see InvocationStrategy to control and extend how systems are invoked.
 	 */
 	public void process() {

--- a/artemis/src/main/java/com/artemis/WorldConfigurationBuilder.java
+++ b/artemis/src/main/java/com/artemis/WorldConfigurationBuilder.java
@@ -236,21 +236,6 @@ public class WorldConfigurationBuilder {
 	}
 
 	/**
-	 * Register passive systems.
-	 * Only one instance of each class is allowed.
-	 * Use {@link #dependsOn} from within plugins.
-	 *
-	 * @param systems  systems to add, order is preserved.
-	 * @param priority priority of added systems, higher priority are added before lower priority.
-	 * @return this
-	 * @throws WorldConfigurationException if type is added more than once.
-	 */
-	public WorldConfigurationBuilder withPassive(int priority, BaseSystem... systems) {
-		addSystems(priority, systems);
-		return this;
-	}
-
-	/**
 	 * helper to queue systems for registration.
 	 */
 	private void addSystems(int priority, BaseSystem[] systems) {


### PR DESCRIPTION
Normally we'd `@deprecate` first but this is falsely advertising functionality we no longer have. Fixes #449.
