### PR TITLE
Fix #483: Upgrade to GWT 2.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 
 #### Version: 2.2.0-SNAPSHOT
+- **BREAKING CHANGES**
+  - Web backend upgraded to GWT 2.8.0
+  - Serialization modules that depend on libGDX now require 1.9.5. (Note: If you (plan to)
+    use bitmap fonts, use 1.9.6-SNAPSHOT or later, bitmap fonts in 1.9.5 are currently broken
+    on web target. see https://github.com/libgdx/libgdx/pull/4475)
 
 
 #### Version: 2.1.0 - 2016-12-09

--- a/artemis-fluid/artemis-fluid-core/src/main/java/com/artemis/FluidGeneratorPreferences.java
+++ b/artemis-fluid/artemis-fluid-core/src/main/java/com/artemis/FluidGeneratorPreferences.java
@@ -30,7 +30,7 @@ public class FluidGeneratorPreferences {
 
     {
         excludeFromClasspath.add("-sources.jar"); // exclude sources
-        excludeFromClasspath.add("gwt-user-2.6.1"); // exclude gwt.
+        excludeFromClasspath.add("gwt-user-"); // exclude gwt.
     }
 
     public FluidGeneratorPreferences() {

--- a/artemis-gwt-test/pom.xml
+++ b/artemis-gwt-test/pom.xml
@@ -11,7 +11,7 @@
 
 	<properties>
 		<junit.version>3.8</junit.version>
-		<gdx.version>1.6.5</gdx.version>
+		<gdx.version>1.9.5</gdx.version>
 		<maven.compiler.source>1.7</maven.compiler.source>
 		<maven.compiler.target>1.7</maven.compiler.target>
 	</properties>
@@ -124,15 +124,14 @@
 			<plugin>
 				<groupId>org.codehaus.mojo</groupId>
 				<artifactId>gwt-maven-plugin</artifactId>
-				<version>2.6.1</version>
+				<version>2.8.0</version>
 				<configuration>
-					<enableClosureCompiler>true</enableClosureCompiler>
 					<disableClassMetadata>false</disableClassMetadata>
 					<disableCastChecking>true</disableCastChecking>
 					<compileReport>true</compileReport>
 					<extraJvmArgs>-Xms64M -Xmx2500M</extraJvmArgs>
 					<localWorkers>4</localWorkers>
-					<sourceLevel>1.7</sourceLevel>
+					<sourceLevel>1.8</sourceLevel>
 					<logLevel>TRACE</logLevel>
 					<draftCompile>true</draftCompile>
 					<testTimeOut>1800</testTimeOut>

--- a/artemis-gwt-test/src/test/resources/com/ArtemisTest.gwt.xml
+++ b/artemis-gwt-test/src/test/resources/com/ArtemisTest.gwt.xml
@@ -56,5 +56,6 @@
 
 	<extend-configuration-property name="gdx.reflect.include" value="com.artemis.managers.CustomJsonWorldSerializationManagerTest" />
 
+	<set-configuration-property name='xsiframe.failIfScriptTag' value='FALSE'/>
 	<set-property name="user.agent" value="safari"/>
 </module>

--- a/artemis-serialization/artemis-json-libgdx/pom.xml
+++ b/artemis-serialization/artemis-json-libgdx/pom.xml
@@ -28,13 +28,13 @@
 		<dependency>
 			<groupId>com.badlogicgames.gdx</groupId>
 			<artifactId>gdx</artifactId>
-			<version>[1.6.0, 2.0.0)</version>
+			<version>[1.9.5, 2.0.0)</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>com.badlogicgames.gdx</groupId>
 			<artifactId>gdx-backend-headless</artifactId>
-			<version>[1.6.0, 2.0.0)</version>
+			<version>[1.9.5, 2.0.0)</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/artemis-serialization/artemis-kryo/pom.xml
+++ b/artemis-serialization/artemis-kryo/pom.xml
@@ -33,7 +33,7 @@
 		<dependency>
 			<groupId>com.badlogicgames.gdx</groupId>
 			<artifactId>gdx</artifactId>
-			<version>[1.6.0, 2.0.0)</version>
+			<version>[1.9.5, 2.0.0)</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>

--- a/artemis-test/pom.xml
+++ b/artemis-test/pom.xml
@@ -38,7 +38,7 @@
 		<dependency>
 			<groupId>com.badlogicgames.gdx</groupId>
 			<artifactId>gdx</artifactId>
-			<version>1.7.0</version>
+			<version>1.9.5</version>
 		</dependency>
 	</dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<asm.version>4.1</asm.version>
 		<junit.version>4.11</junit.version>
-		<gwt.version>2.6.1</gwt.version>
+		<gwt.version>2.8.0</gwt.version>
 		<matrix.artemis.version>0.2.0</matrix.artemis.version>
 		<assembly.plugin.version>2.5.5</assembly.plugin.version>
 		<jar.plugin.version>2.6</jar.plugin.version>


### PR DESCRIPTION
  - Web backend upgraded to GWT 2.8.0
  - Serialization modules that depend on libGDX now require 1.9.5. (Note: If you (plan to)
    use bitmap fonts, use 1.9.6-SNAPSHOT or later, bitmap fonts in 1.9.5 are currently broken
    on web target. see https://github.com/libgdx/libgdx/pull/4475)