### PR TITLE
Aspect of first entity subscription is ignored for SubscriptionListener.removed

### DIFF
--- a/artemis/src/main/java/com/artemis/AspectSubscriptionManager.java
+++ b/artemis/src/main/java/com/artemis/AspectSubscriptionManager.java
@@ -1,15 +1,15 @@
 package com.artemis;
 
-import com.artemis.annotations.SkipWire;
-import com.artemis.utils.Bag;
-import com.artemis.utils.ImmutableBag;
-import com.artemis.utils.IntBag;
+import static com.artemis.Aspect.all;
 
-import com.artemis.utils.BitVector;
 import java.util.HashMap;
 import java.util.Map;
 
-import static com.artemis.Aspect.all;
+import com.artemis.annotations.SkipWire;
+import com.artemis.utils.Bag;
+import com.artemis.utils.BitVector;
+import com.artemis.utils.ImmutableBag;
+import com.artemis.utils.IntBag;
 
 /**
  * <p>Manages all instances of {@link EntitySubscription}.</p>
@@ -37,8 +37,10 @@ public class AspectSubscriptionManager extends BaseSystem {
 	protected void processSystem() {}
 
 	@Override
-	protected void initialize() {
-		// making sure subscription 1 matches all entities
+	protected void setWorld(World world) {
+		super.setWorld(world);
+
+		// making sure the first subscription matches all entities
 		get(all());
 	}
 
@@ -65,16 +67,13 @@ public class AspectSubscriptionManager extends BaseSystem {
 
 	/**
 	 * Informs all listeners of added, changedBits and deletedBits changes.
+	 * 
+	 * Order of {@link EntitySubscription.SubscriptionListener} can vary
+	 * (typically ordinal, except for subscriptions created in process,
+	 * initialize instead of setWorld).
 	 *
-	 * Two types of listeners:
-	 * {@see EntityObserver} implementations are guaranteed to be called back in order of system registration.
-	 * {@see com.artemis.EntitySubscription.SubscriptionListener}, where order can vary (typically ordinal, except
-	 * for subscriptions created in process, initialize instead of setWorld).
-     *
 	 * {@link com.artemis.EntitySubscription.SubscriptionListener#inserted(IntBag)}
 	 * {@link com.artemis.EntitySubscription.SubscriptionListener#removed(IntBag)}
-	 *
-	 * Observers are called before Subscriptions, which means managerial tasks get artificial priority.
 	 *
 	 * @param changedBits Entities with changedBits composition or state.
 	 * @param deletedBits Entities removed from world.

--- a/artemis/src/main/java/com/artemis/EntitySubscription.java
+++ b/artemis/src/main/java/com/artemis/EntitySubscription.java
@@ -2,10 +2,8 @@ package com.artemis;
 
 import com.artemis.annotations.DelayedComponentRemoval;
 import com.artemis.utils.Bag;
-import com.artemis.utils.IntBag;
-
 import com.artemis.utils.BitVector;
-
+import com.artemis.utils.IntBag;
 
 /**
  * Maintains the list of entities matched by an aspect. Entity subscriptions
@@ -40,8 +38,7 @@ public class EntitySubscription {
 	}
 
 	/**
-	 * Returns a reference to the bag holding all matched
-	 * entities.
+	 * Returns a reference to the bag holding all matched entities.
 	 *
 	 * <p><b>Warning: </b> Never remove elements from the bag, as this
 	 * will lead to undefined behavior.</p>
@@ -164,7 +161,7 @@ public class EntitySubscription {
 		int[] ids = entities.getData();
 		for (int i = 0, s = entities.size(); s > i; i++) {
 			int id = ids[i];
-			if(activeEntityIds.unsafeGet(id))
+			if (activeEntityIds.unsafeGet(id))
 				remove(id);
 		}
 	}


### PR DESCRIPTION
Since internal systems (ComponentManager, EntityManager) don't use subscriptions anymore, calling `subscriptions.get(0).processAll(changed, deleted);` in `AspectSubscriptionManager.process(...)` results in unintended behaviour: 
The first added EntitySubscription will ignore the provided aspect for deleted entities.