### PR TITLE
World is now injected with world.inject(object) #479

### DIFF
--- a/artemis-serialization/artemis-json-libgdx/src/main/java/com/artemis/io/EntityBagSerializer.java
+++ b/artemis-serialization/artemis-json-libgdx/src/main/java/com/artemis/io/EntityBagSerializer.java
@@ -2,12 +2,13 @@ package com.artemis.io;
 
 import com.artemis.Entity;
 import com.artemis.World;
+import com.artemis.annotations.SkipWire;
 import com.artemis.utils.Bag;
 import com.badlogic.gdx.utils.Json;
 import com.badlogic.gdx.utils.JsonValue;
 
 public class EntityBagSerializer implements Json.Serializer<Bag> {
-	private final World world;
+	@SkipWire private final World world;
 
 	public EntityBagSerializer(World world) {
 		this.world = world;

--- a/artemis-serialization/artemis-json-libgdx/src/main/java/com/artemis/io/EntitySerializer.java
+++ b/artemis-serialization/artemis-json-libgdx/src/main/java/com/artemis/io/EntitySerializer.java
@@ -1,6 +1,7 @@
 package com.artemis.io;
 
 import com.artemis.*;
+import com.artemis.annotations.SkipWire;
 import com.artemis.annotations.Wire;
 import com.artemis.components.SerializationTag;
 import com.artemis.managers.GroupManager;
@@ -17,7 +18,7 @@ public class EntitySerializer implements Json.Serializer<Entity> {
 
 	private final Bag<Component> components = new Bag<Component>();
 	private final ComponentNameComparator comparator = new ComponentNameComparator();
-	private final World world;
+	@SkipWire private final World world;
 	private final ReferenceTracker referenceTracker;
 	private final DefaultObjectStore defaultValues;
 	final EntityPoolFactory factory;

--- a/artemis-serialization/artemis-json-libgdx/src/main/java/com/artemis/io/IntBagEntitySerializer.java
+++ b/artemis-serialization/artemis-json-libgdx/src/main/java/com/artemis/io/IntBagEntitySerializer.java
@@ -2,6 +2,7 @@ package com.artemis.io;
 
 import com.artemis.Entity;
 import com.artemis.World;
+import com.artemis.annotations.SkipWire;
 import com.artemis.annotations.Wire;
 import com.artemis.utils.Bag;
 import com.artemis.utils.IntBag;
@@ -9,7 +10,7 @@ import com.badlogic.gdx.utils.Json;
 import com.badlogic.gdx.utils.JsonValue;
 
 public class IntBagEntitySerializer implements Json.Serializer<IntBag> {
-	private final World world;
+	@SkipWire private final World world;
 	private final Bag<Entity> translatedIds = new Bag<Entity>();
 
 	private int recursionLevel;

--- a/artemis-serialization/artemis-json-libgdx/src/test/java/com/artemis/managers/CustomJsonWorldSerializationManagerTest.java
+++ b/artemis-serialization/artemis-json-libgdx/src/test/java/com/artemis/managers/CustomJsonWorldSerializationManagerTest.java
@@ -1,6 +1,7 @@
 package com.artemis.managers;
 
 import com.artemis.*;
+import com.artemis.annotations.SkipWire;
 import com.artemis.annotations.Wire;
 import com.artemis.io.JsonArtemisSerializer;
 import com.artemis.io.SaveFileFormat;
@@ -22,7 +23,7 @@ public class CustomJsonWorldSerializationManagerTest {
 	private WorldSerializationManager manger;
 	private AspectSubscriptionManager subscriptions;
 	private SerializedSystem serializedSystem;
-	private World world;
+	@SkipWire private World world;
 	private EntitySubscription allEntities;
 
 	@Before

--- a/artemis-serialization/artemis-json/src/main/java/com/artemis/io/EntityBagSerializer.java
+++ b/artemis-serialization/artemis-json/src/main/java/com/artemis/io/EntityBagSerializer.java
@@ -2,13 +2,14 @@ package com.artemis.io;
 
 import com.artemis.Entity;
 import com.artemis.World;
+import com.artemis.annotations.SkipWire;
 import com.artemis.utils.Bag;
 import com.esotericsoftware.jsonbeans.Json;
 import com.esotericsoftware.jsonbeans.JsonSerializer;
 import com.esotericsoftware.jsonbeans.JsonValue;
 
 public class EntityBagSerializer implements JsonSerializer<Bag> {
-	private final World world;
+	@SkipWire private final World world;
 
 	public EntityBagSerializer(World world) {
 		this.world = world;

--- a/artemis-serialization/artemis-json/src/main/java/com/artemis/io/EntitySerializer.java
+++ b/artemis-serialization/artemis-json/src/main/java/com/artemis/io/EntitySerializer.java
@@ -1,6 +1,7 @@
 package com.artemis.io;
 
 import com.artemis.*;
+import com.artemis.annotations.SkipWire;
 import com.artemis.annotations.Wire;
 import com.artemis.components.SerializationTag;
 import com.artemis.managers.GroupManager;
@@ -18,7 +19,7 @@ public class EntitySerializer implements JsonSerializer<Entity> {
 
 	private final Bag<Component> components = new Bag<Component>();
 	private final ComponentNameComparator comparator = new ComponentNameComparator();
-	private final World world;
+	@SkipWire private final World world;
 	private final ReferenceTracker referenceTracker;
 	private final DefaultObjectStore defaultValues;
 	final EntityPoolFactory factory;

--- a/artemis-serialization/artemis-json/src/main/java/com/artemis/io/IntBagEntitySerializer.java
+++ b/artemis-serialization/artemis-json/src/main/java/com/artemis/io/IntBagEntitySerializer.java
@@ -2,6 +2,7 @@ package com.artemis.io;
 
 import com.artemis.Entity;
 import com.artemis.World;
+import com.artemis.annotations.SkipWire;
 import com.artemis.utils.Bag;
 import com.artemis.utils.IntBag;
 import com.esotericsoftware.jsonbeans.Json;
@@ -9,7 +10,7 @@ import com.esotericsoftware.jsonbeans.JsonSerializer;
 import com.esotericsoftware.jsonbeans.JsonValue;
 
 public class IntBagEntitySerializer implements JsonSerializer<IntBag> {
-	private final World world;
+	@SkipWire private final World world;
 	private final Bag<Entity> translatedIds = new Bag<Entity>();
 
 	private int recursionLevel;

--- a/artemis-serialization/artemis-json/src/test/java/com/artemis/managers/CustomJsonWorldSerializationManagerTest.java
+++ b/artemis-serialization/artemis-json/src/test/java/com/artemis/managers/CustomJsonWorldSerializationManagerTest.java
@@ -1,6 +1,7 @@
 package com.artemis.managers;
 
 import com.artemis.*;
+import com.artemis.annotations.SkipWire;
 import com.artemis.annotations.Wire;
 import com.artemis.io.JsonArtemisSerializer;
 import com.artemis.io.SaveFileFormat;
@@ -23,7 +24,7 @@ public class CustomJsonWorldSerializationManagerTest {
 	private WorldSerializationManager manger;
 	private AspectSubscriptionManager subscriptions;
 	private SerializedSystem serializedSystem;
-	private World world;
+	@SkipWire private World world;
 	private EntitySubscription allEntities;
 
 	@Before

--- a/artemis/src/main/java/com/artemis/BaseSystem.java
+++ b/artemis/src/main/java/com/artemis/BaseSystem.java
@@ -1,5 +1,7 @@
 package com.artemis;
 
+import com.artemis.annotations.SkipWire;
+
 /**
  * Most basic system.
  *
@@ -15,6 +17,7 @@ package com.artemis;
  */
 public abstract class BaseSystem {
 	/** The world this system belongs to. */
+	@SkipWire
 	protected World world;
 
 	public BaseSystem() {}

--- a/artemis/src/main/java/com/artemis/injection/ArtemisFieldResolver.java
+++ b/artemis/src/main/java/com/artemis/injection/ArtemisFieldResolver.java
@@ -10,7 +10,7 @@ import java.util.IdentityHashMap;
 import java.util.Map;
 
 /**
- * Can resolve {@link com.artemis.ComponentMapper}, {@link com.artemis.BaseSystem} and
+ * Can resolve {@link com.artemis.World}, {@link com.artemis.ComponentMapper}, {@link com.artemis.BaseSystem} and
  * {@link com.artemis.Manager} types registered in the {@link World}
  *
  * @author Snorre E. Brekke
@@ -48,6 +48,8 @@ public class ArtemisFieldResolver implements FieldResolver, UseInjectionCache {
 				return getComponentMapper(field);
 			case SYSTEM:
 				return world.getSystem((Class<BaseSystem>) systems.get(fieldType));
+			case WORLD:
+				return world;
 			default:
 				return null;
 

--- a/artemis/src/main/java/com/artemis/injection/ArtemisFieldResolver.java
+++ b/artemis/src/main/java/com/artemis/injection/ArtemisFieldResolver.java
@@ -51,18 +51,7 @@ public class ArtemisFieldResolver implements FieldResolver, UseInjectionCache {
 			case SYSTEM:
 				return world.getSystem((Class<BaseSystem>) systems.get(fieldType));
 			case WORLD:
-				try {
-					field.setAccessible(true);
-					// we don't want to override world fields if they ware @Wired in or set in manually before injection
-					Object current = field.get(target);
-					if (current == null) {
-						return world;
-					} else {
-						return current;
-					}
-				} catch (ReflectionException e) {
-					return null;
-				}
+				return world;
 			default:
 				return null;
 

--- a/artemis/src/main/java/com/artemis/injection/AspectFieldResolver.java
+++ b/artemis/src/main/java/com/artemis/injection/AspectFieldResolver.java
@@ -34,7 +34,7 @@ public class AspectFieldResolver implements FieldResolver {
 
 	@Override
 	@SuppressWarnings("unchecked")
-	public Object resolve(Class<?> fieldType, Field field) {
+	public Object resolve(Object target, Class<?> fieldType, Field field) {
 		Aspect.Builder aspect = aspect(field);
 		if (aspect == null)
 			return null;

--- a/artemis/src/main/java/com/artemis/injection/CachedInjector.java
+++ b/artemis/src/main/java/com/artemis/injection/CachedInjector.java
@@ -156,7 +156,7 @@ public final class CachedInjector implements Injector {
 			return;
 		}
 
-		Object resolve = fieldHandler.resolve(fieldType, field);
+		Object resolve = fieldHandler.resolve(target, fieldType, field);
 		if (resolve != null) {
 			setField(target, field, resolve);
 		}

--- a/artemis/src/main/java/com/artemis/injection/ClassType.java
+++ b/artemis/src/main/java/com/artemis/injection/ClassType.java
@@ -15,6 +15,10 @@ public enum ClassType {
 	 */
 	SYSTEM,
 	/**
+	 * Used for (sub)classes of {@link com.artemis.World}
+	 */
+	WORLD,
+	/**
 	 * Used for everything else.
 	 */
 	CUSTOM

--- a/artemis/src/main/java/com/artemis/injection/FieldHandler.java
+++ b/artemis/src/main/java/com/artemis/injection/FieldHandler.java
@@ -12,11 +12,11 @@ import java.util.Map;
  * FieldHandler provides dependency-values to an {@link com.artemis.injection.Injector}
  * by sequentially iterating over a list of registered {@link FieldResolver}.
  * <p>
- * The method {@link #resolve(Class, Field)} will return the first non-null value provided by
- * {@link FieldResolver#resolve(Class, Field)}, or null if no resolver returned a valid value.
+ * The method {@link #resolve(Object, Class, Field)} will return the first non-null value provided by
+ * {@link FieldResolver#resolve(Object, Class, Field)}, or null if no resolver returned a valid value.
  * </p>
  * <p>
- * During {@link World} construction, after systems and managers have been created, {@link #initialize(World)}
+ * During {@link World} construction, after systems and managers have been created, {@link #initialize(World, Map)}
  * will be called for each registered {@link FieldResolver}
  * </p>
  * <p>
@@ -61,13 +61,14 @@ public class FieldHandler {
 	public FieldHandler(InjectionCache cache) {
 		this.fieldResolvers = new Bag(FieldResolver.class);
 		this.cache = cache;
+		// the order FieldResolvers are added is relevant, we want to prioritize @Wired fields
+		addFieldResolver(new WiredFieldResolver());
 		addFieldResolver(new ArtemisFieldResolver());
 		addFieldResolver(new AspectFieldResolver());
-		addFieldResolver(new WiredFieldResolver());
 	}
 
 	/**
-	 * During {@link World} construction, after systems and managers have been created, {@link #initialize(World)}
+	 * During {@link World} construction, after systems and managers have been created, {@link #initialize(World, Map)}
 	 * will be called for each registered {@link FieldResolver}
 	 * </p>
 	 * <p/>
@@ -104,16 +105,16 @@ public class FieldHandler {
 
 	/**
 	 * Returns the first non-null value provided by
-	 * {@link FieldResolver#resolve(Class, Field)}, or null if no resolver returned a valid value.
+	 * {@link FieldResolver#resolve(Object, Class, Field)}, or null if no resolver returned a valid value.
 	 *
 	 * @param fieldType class of the field
 	 * @param field     field for which a value should be resolved
 	 * @return a non-null value if any {@link FieldResolver} could provide an instance
 	 * for the {@code field}, null if the {@code field} could not be resolved
 	 */
-	public Object resolve(Class<?> fieldType, Field field) {
+	public Object resolve(Object target, Class<?> fieldType, Field field) {
 		for (int i = 0, s = fieldResolvers.size(); i < s; i++) {
-			Object resolved = fieldResolvers.get(i).resolve(fieldType, field);
+			Object resolved = fieldResolvers.get(i).resolve(target, fieldType, field);
 			if (resolved != null) {
 				return resolved;
 			}

--- a/artemis/src/main/java/com/artemis/injection/FieldResolver.java
+++ b/artemis/src/main/java/com/artemis/injection/FieldResolver.java
@@ -17,5 +17,5 @@ public interface FieldResolver {
 	 */
 	void initialize(World world);
 
-	Object resolve(Class<?> fieldType, Field field);
+	Object resolve(Object target, Class<?> fieldType, Field field);
 }

--- a/artemis/src/main/java/com/artemis/injection/InjectionCache.java
+++ b/artemis/src/main/java/com/artemis/injection/InjectionCache.java
@@ -2,6 +2,7 @@ package com.artemis.injection;
 
 import com.artemis.BaseSystem;
 import com.artemis.ComponentMapper;
+import com.artemis.World;
 import com.artemis.annotations.SkipWire;
 import com.artemis.annotations.Wire;
 import com.artemis.utils.reflect.ClassReflection;
@@ -114,6 +115,8 @@ public class InjectionCache {
 				injectionType = ClassType.MAPPER;
 			} else if (ClassReflection.isAssignableFrom(BaseSystem.class, fieldType)) {
 				injectionType = ClassType.SYSTEM;
+			} else if (ClassReflection.isAssignableFrom(World.class, fieldType)) {
+				injectionType = ClassType.WORLD;
 			} else {
 				injectionType = ClassType.CUSTOM;
 			}

--- a/artemis/src/main/java/com/artemis/injection/WiredFieldResolver.java
+++ b/artemis/src/main/java/com/artemis/injection/WiredFieldResolver.java
@@ -39,14 +39,9 @@ public class WiredFieldResolver implements UseInjectionCache, PojoFieldResolver 
 					key = field.getType().getName();
 				}
 
-				if (!pojos.containsKey(key)) {
-					// hack to wire in world even if it is not registered
-					if (field.getType() == World.class && world != null) {
-						return world;
-					} else if (cachedField.failOnNull) {
-						String err = "Not registered: " + key + "=" + fieldType;
-						throw new MundaneWireException(err);
-					}
+				if (!pojos.containsKey(key) && cachedField.failOnNull) {
+					String err = "Not registered: " + key + "=" + fieldType;
+					throw new MundaneWireException(err);
 				}
 
 				return pojos.get(key);

--- a/artemis/src/test/java/com/artemis/FieldHandlerTest.java
+++ b/artemis/src/test/java/com/artemis/FieldHandlerTest.java
@@ -50,6 +50,22 @@ public class FieldHandlerTest {
         assertNotNull(objectsInjected.string);
     }
 
+    @Test
+    public void default_field_handler_injects_world_fields() throws Exception {
+        WorldConfiguration worldConfiguration = new WorldConfiguration();
+        World world = new World(worldConfiguration);
+
+        CustomObjectWithWorldField withWorldField = new CustomObjectWithWorldField();
+
+        world.inject(withWorldField);
+
+        assertNotNull(withWorldField.world);
+    }
+
+    private static class CustomObjectWithWorldField {
+        private World world;
+    }
+
     private static class ObjectWithNoArgsConstructorFields{
         private Object object;
         private String string;
@@ -82,7 +98,7 @@ public class FieldHandlerTest {
         }
 
         @Override
-        public Object resolve(Class<?> fieldType, Field field) {
+        public Object resolve(Object target, Class<?> fieldType, Field field) {
             try {
                 return ClassReflection.newInstance(fieldType);
             } catch (ReflectionException e) {

--- a/artemis/src/test/java/com/artemis/MultiWorldTest.java
+++ b/artemis/src/test/java/com/artemis/MultiWorldTest.java
@@ -3,6 +3,7 @@ package com.artemis;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 
+import com.artemis.annotations.SkipWire;
 import org.junit.Test;
 
 import com.artemis.component.ComponentX;
@@ -53,6 +54,7 @@ public class MultiWorldTest
 	public static class InnerWorldProcessingSystem
 			extends VoidEntitySystem {
 
+		@SkipWire
 		private final World inner;
 
 		public InnerWorldProcessingSystem(World inner) {

--- a/artemis/src/test/java/com/artemis/PojoFieldResolverTest.java
+++ b/artemis/src/test/java/com/artemis/PojoFieldResolverTest.java
@@ -79,7 +79,7 @@ public class PojoFieldResolverTest {
 		}
 
 		@Override
-		public Object resolve(Class<?> fieldType, Field field) {
+		public Object resolve(Object target, Class<?> fieldType, Field field) {
 			return null;
 		}
 	}

--- a/artemis/src/test/java/com/artemis/WireTest.java
+++ b/artemis/src/test/java/com/artemis/WireTest.java
@@ -214,6 +214,8 @@ public class WireTest {
 		world.inject(st);
 
 		assertNotNull(st.tagManager);
+		assertNotNull(st.world1);
+		assertNotNull(st.world2);
 		assertEquals("n1", st.helloN1);
 		assertEquals("world", st.hello);
 		assertEquals("n2", st.helloN2);
@@ -265,6 +267,8 @@ public class WireTest {
 		@Wire(name="hupp", failOnNull=false) private String helloN1;
 		@Wire private String hello;
 		@Wire(name="blergh", failOnNull=false) private String helloN2;
+		@Wire World world1;
+		World world2;
 		
 		private TagManager tagManager;
 	}

--- a/artemis/src/test/java/com/artemis/WireTest.java
+++ b/artemis/src/test/java/com/artemis/WireTest.java
@@ -1,5 +1,6 @@
 package com.artemis;
 
+import com.artemis.annotations.SkipWire;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -214,8 +215,7 @@ public class WireTest {
 		world.inject(st);
 
 		assertNotNull(st.tagManager);
-		assertNotNull(st.world1);
-		assertNotNull(st.world2);
+		assertNotNull(st.world);
 		assertEquals("n1", st.helloN1);
 		assertEquals("world", st.hello);
 		assertEquals("n2", st.helloN2);
@@ -224,15 +224,30 @@ public class WireTest {
 	@Test
 	public void inject_wired_world_and_notwired_world_into_everything() {
 		World wiredWorld = new World(new WorldConfiguration());
+		World setWorld = new World(new WorldConfiguration());
 		World world = new World(new WorldConfiguration()
-				.register(wiredWorld));
+			.register(wiredWorld));
 
 		WiredNotWiredWorldThing wt = new WiredNotWiredWorldThing();
+		wt.worldSet = setWorld;
 		world.inject(wt);
 
 		assertNotNull(wt.worldWired);
 		assertNotNull(wt.worldNotWired);
+		assertNotNull(wt.worldSet);
 		assertNotEquals(wt.worldWired, wt.worldNotWired);
+		assertNotEquals(wt.worldWired, wt.worldSet);
+		assertNotEquals(wt.worldNotWired, wt.worldSet);
+	}
+
+	@Test(expected = MundaneWireException.class)
+	public void inject_wired_world_missing() {
+		World world = new World(new WorldConfiguration());
+
+		WiredNotWiredWorldThing wt = new WiredNotWiredWorldThing();
+		world.inject(wt);
+
+		assertTrue("Should fail!", true);
 	}
 
 	@Test
@@ -281,8 +296,7 @@ public class WireTest {
 		@Wire(name="hupp", failOnNull=false) private String helloN1;
 		@Wire private String hello;
 		@Wire(name="blergh", failOnNull=false) private String helloN2;
-		@Wire World world1;
-		World world2;
+		World world;
 		
 		private TagManager tagManager;
 	}
@@ -296,6 +310,7 @@ public class WireTest {
 	private static class WiredNotWiredWorldThing {
 		@Wire World worldWired;
 		World worldNotWired;
+		@SkipWire World worldSet;
 	}
 	
 	private static class MappedSystemAll extends EntityProcessingSystem {

--- a/artemis/src/test/java/com/artemis/WireTest.java
+++ b/artemis/src/test/java/com/artemis/WireTest.java
@@ -222,6 +222,20 @@ public class WireTest {
 	}
 
 	@Test
+	public void inject_wired_world_and_notwired_world_into_everything() {
+		World wiredWorld = new World(new WorldConfiguration());
+		World world = new World(new WorldConfiguration()
+				.register(wiredWorld));
+
+		WiredNotWiredWorldThing wt = new WiredNotWiredWorldThing();
+		world.inject(wt);
+
+		assertNotNull(wt.worldWired);
+		assertNotNull(wt.worldNotWired);
+		assertNotEquals(wt.worldWired, wt.worldNotWired);
+	}
+
+	@Test
 	public void try_inject_on_wired_object_mirrors_inject_behaviour() {
 		World world = new World(new WorldConfiguration().register("world").setSystem(TagManager.class));
 		SomeThing st = new SomeThing();
@@ -277,6 +291,11 @@ public class WireTest {
 		private ComponentMapper<ComponentX> componentXMapper;
 		private TagManager tagManager;
 		private MappedSystem mappedSystem;
+	}
+
+	private static class WiredNotWiredWorldThing {
+		@Wire World worldWired;
+		World worldNotWired;
 	}
 	
 	private static class MappedSystemAll extends EntityProcessingSystem {


### PR DESCRIPTION
Systems still use setWorld() as ComponentManager and EntityManager are marked as SkipWire.