### PR TITLE
Add classesDirs to Gradle wrapper; update ASM to 7.0

### DIFF
--- a/artemis-build-tools/artemis-maven/pom.xml
+++ b/artemis-build-tools/artemis-maven/pom.xml
@@ -50,7 +50,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-plugin-plugin</artifactId>
-				<version>3.3</version>
+				<version>3.6.0</version>
 				<configuration>
 					<!-- see http://jira.codehaus.org/browse/MNG-5346 -->
 					<skipErrorNoDescriptorsFound>true</skipErrorNoDescriptorsFound>

--- a/artemis-build-tools/artemis-weaver/pom.xml
+++ b/artemis-build-tools/artemis-weaver/pom.xml
@@ -10,9 +10,9 @@
 	<artifactId>artemis-odb-weaver</artifactId>
 	<packaging>jar</packaging>
 	<name>artemis-odb-component-weaver</name>
-	
+
 	<properties>
-		<asm.version>5.0.4</asm.version>
+		<asm.version>7.0</asm.version>
 		<mainClass>net.onedaybeard.agrotera.ProcessArtemis</mainClass>
 	</properties>
 

--- a/artemis-build-tools/artemis-weaver/src/main/java/com/artemis/ClassUtil.java
+++ b/artemis-build-tools/artemis-weaver/src/main/java/com/artemis/ClassUtil.java
@@ -7,6 +7,7 @@ import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 
 import org.objectweb.asm.AnnotationVisitor;
 import org.objectweb.asm.ClassReader;
@@ -56,17 +57,16 @@ public final class ClassUtil implements Opcodes
 		return sw.toString();
 	}
 	
-	public static List<File> find(String root) {
-		return find(new File(root));
-	}
-	
-	public static List<File> find(File root) {
-		if (!root.isDirectory())
-			throw new IllegalAccessError(root + " must be a folder.");
-		
-		List<File> klazzes = new ArrayList<File>();
-		addFiles(klazzes, root);
-			
+	public static List<File> find(Set<File> roots) {
+		List<File> klazzes = new ArrayList<>();
+
+		for (File root : roots) {
+			if (!root.isDirectory())
+				throw new IllegalAccessError(root + " must be a folder.");
+
+			addFiles(klazzes, root);
+		}
+
 		return klazzes;
 	}
 	

--- a/artemis-build-tools/artemis-weaver/src/main/java/com/artemis/ClassUtil.java
+++ b/artemis-build-tools/artemis-weaver/src/main/java/com/artemis/ClassUtil.java
@@ -6,6 +6,7 @@ import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
@@ -55,6 +56,10 @@ public final class ClassUtil implements Opcodes
 		CheckClassAdapter.verify(new ClassReader(writer.toByteArray()), false, printer);
 
 		return sw.toString();
+	}
+
+	public static List<File> find(File root) {
+		return find(Collections.singleton(root));
 	}
 	
 	public static List<File> find(Set<File> roots) {

--- a/artemis-build-tools/artemis-weaver/src/main/java/com/artemis/Weaver.java
+++ b/artemis-build-tools/artemis-weaver/src/main/java/com/artemis/Weaver.java
@@ -10,6 +10,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
@@ -29,17 +30,21 @@ public class Weaver {
 	public static final String POOLED_ANNOTATION = "Lcom/artemis/annotations/PooledWeaver;";
 	public static final String WOVEN_ANNOTATION = "Lcom/artemis/annotations/internal/Transmuted";
 	public static final String PRESERVE_VISIBILITY_ANNOTATION = "Lcom/artemis/annotations/PreserveProcessVisiblity;";
-	
-	private final File targetClasses;
-	
+
+	private Set<File> classesDirs;
+
 	public Weaver(File outputDirectory) {
-		this.targetClasses = outputDirectory;
+		this.classesDirs = Collections.singleton(outputDirectory);
 	}
-	
+
+	public Weaver(Set<File> outputDirectories) {
+		this.classesDirs = outputDirectories;
+	}
+
 	public WeaverLog execute() {
 		WeaverLog log = new WeaverLog();
-		
-		List<File> classes = ClassUtil.find(targetClasses);
+
+		List<File> classes = ClassUtil.find(classesDirs);
 		rewriteComponents(classes, log);
 		generateLinkMutators(classes, log);
 		rewriteProfilers(classes);

--- a/artemis-build-tools/artemis-weaver/src/main/java/com/artemis/weaver/EntityLinkGenerator.java
+++ b/artemis-build-tools/artemis-weaver/src/main/java/com/artemis/weaver/EntityLinkGenerator.java
@@ -95,7 +95,7 @@ public class EntityLinkGenerator extends CallableTransmuter<Void> implements Opc
 		final ClassReader sourceClassReader = Weaver.toClassReader(fd.entityLinkMutator);
 		ClassWriter cw = new ClassWriter(ClassWriter.COMPUTE_FRAMES);
 		ClassVisitor cv = cw;
-		final String typeName = meta.type.getInternalName() + getMutatorName(fd);
+		final String className = meta.type.getInternalName() + getMutatorName(fd);
 		cv = new ClassVisitor(ASM5, cv) {
 			@Override
 			public MethodVisitor visitMethod(int access, String name, String desc, String signature, String[] exceptions) {
@@ -108,7 +108,7 @@ public class EntityLinkGenerator extends CallableTransmuter<Void> implements Opc
 			@Override
 			public MethodVisitor visitMethod(int access, String name, String desc, String signature, String[] exceptions) {
 				final MethodVisitor mv = super.visitMethod(access, name, desc, signature, exceptions);
-				return new MethodBodyTransplanter(fd.entityLinkMutator, Type.getType(typeName), mv);
+				return new MethodBodyTransplanter(fd.entityLinkMutator, Type.getObjectType(className), mv);
 			}
 		};
 		cv = new ClassVisitor(ASM5, cv) {
@@ -164,11 +164,11 @@ public class EntityLinkGenerator extends CallableTransmuter<Void> implements Opc
 			@Override
 			public MethodVisitor visitMethod(int access, String name, String desc, String signature, String[] exceptions) {
 				MethodVisitor mv = super.visitMethod(access, name, desc, signature, exceptions);
-				Type target = Type.getType(meta.type.getInternalName() + "$Mutator_" + fd.name);
+				Type target = Type.getObjectType(meta.type.getInternalName() + "$Mutator_" + fd.name);
 				return new MethodBodyTransplanter(sourceClassReader.getClassName(), target, mv);
 			}
 		};
-		cv = new ClassTransplantVisitor(sourceClassReader, cv, Weaver.scan(fd.entityLinkMutator), typeName);
+		cv = new ClassTransplantVisitor(sourceClassReader, cv, Weaver.scan(fd.entityLinkMutator), className);
 
 		try {
 			sourceClassReader.accept(cv, ClassReader.EXPAND_FRAMES);

--- a/artemis-build-tools/artemis-weaver/src/main/java/com/artemis/weaver/optimizer/EntitySystemType.java
+++ b/artemis-build-tools/artemis-weaver/src/main/java/com/artemis/weaver/optimizer/EntitySystemType.java
@@ -24,7 +24,7 @@ public enum EntitySystemType {
 
 	public static EntitySystemType resolve(String owner) {
 		for (EntitySystemType type : EntitySystemType.values()) {
-			if (owner.equals(type.superName))
+			if (type.superName.equals(owner))
 				return type;
 		}
 

--- a/artemis-build-tools/artemis-weaver/src/main/java/com/artemis/weaver/transplant/MethodBodyTransplanter.java
+++ b/artemis-build-tools/artemis-weaver/src/main/java/com/artemis/weaver/transplant/MethodBodyTransplanter.java
@@ -13,7 +13,7 @@ public class MethodBodyTransplanter extends MethodVisitor {
 
 	public MethodBodyTransplanter(String oldOwner, ClassMetadata meta, MethodVisitor mv) {
 		super(Opcodes.ASM5, mv);
-		this.oldOwner = Type.getType(oldOwner);;
+		this.oldOwner = Type.getObjectType(oldOwner);
 		type = meta.type;
 		this.owner = meta.type.getInternalName();
 	}
@@ -27,7 +27,7 @@ public class MethodBodyTransplanter extends MethodVisitor {
 
 	public MethodBodyTransplanter(String oldOwner, Type newType, MethodVisitor mv) {
 		super(Opcodes.ASM5, mv);
-		this.oldOwner = Type.getType(oldOwner);
+		this.oldOwner = Type.getObjectType(oldOwner);
 		this.type = newType;
 		this.owner = newType.getInternalName();
 	}

--- a/artemis-fluid/artemis-fluid-maven-plugin/pom.xml
+++ b/artemis-fluid/artemis-fluid-maven-plugin/pom.xml
@@ -51,7 +51,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-plugin-plugin</artifactId>
-                <version>3.3</version>
+                <version>3.6.0</version>
                 <configuration>
                     <!-- see http://jira.codehaus.org/browse/MNG-5346 -->
                     <skipErrorNoDescriptorsFound>true</skipErrorNoDescriptorsFound>


### PR DESCRIPTION
This adds support for `classesDirs` in `artemis-odb-gradle-plugin`. This is useful for projects that have multiple class output directories (eg. Java & Kotlin) and mirrors the change in Gradle 4 that deprecated `SourceSetOutput#classesDir`.

Before:
```gradle
weave {
    classesDir = sourceSets.main.output.classesDir
    // ...                Deprecated in Gradle 4 ^
```

After:
```gradle
weave {
    classesDirs = sourceSets.main.output.classesDirs
    // Now includes both Java & Kotlin output directories!
```

Other changes are:
- Avoiding an NPE in `optimizer.EntitySystemType` if `meta.superClass` is null.
- Upgrading ObjectWeb ASM to 7.0 to avoid choking on more modern bytecode (Java 9's `module-info.class` in particular)
- Minor fixes to support the upgrade to ASM 7.0 (`Type.getObjectType` accepts a class name, whereas `Type.getType` expects a full type descriptor, eg. `Ljava/lang/String;`)
- Use latest version of `maven-plugin-plugin`, since the `helpmojo` goal was spitting out ASM errors on my machine.

If this is too many changes for one PR, please let me know and I can split out the important parts.