### PR TITLE
Adds required extension points for debugger and editor plugins.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,12 @@
   - New `EntitySubscription` facade `ESubscription`, for convenient `E` iteration. 
   - Annotation driven aspects allow DI of `ESubscription` (requires registered `FluidEntityPlugin`)
   - Ability to exclude specific component methods from the fluid API. `@FluidMethod(exclude=true)`
-  - `E` toString now reports entity id for easier debugging. ie: `E{id=10}`.    
-- Gradle plugin now supports `classesDirs`, deprecated `classesDir.
-- Improve flexibility of logic behind annotations dependency injection. (no user impact).
+  - `E` toString now reports entity id for easier debugging. ie: `E{id=10}`.
+- Other    
+  - Improve flexibility of logic behind annotations dependency injection. (no user impact).
+  - New extension point for debuggers and editors. (`InternalFactory`)
+  - New lifecycle phase listener for debuggers and editors.  
+  - Gradle plugin now supports `classesDirs`, deprecated `classesDir.
 - **FIX**: Avoiding an NPE in optimizer.EntitySystemType if meta.superClass is null.
 - **FIX**: ObjectWeb ASM updated to 7.0 to avoid choking on more modern bytecode.
 

--- a/artemis-backend-gwt/artemis-gwt/src/main/java/com/artemis/backends/gwt/emu/com/artemis/ComponentManager.java
+++ b/artemis-backend-gwt/artemis-gwt/src/main/java/com/artemis/backends/gwt/emu/com/artemis/ComponentManager.java
@@ -59,12 +59,15 @@ public class ComponentManager extends BaseSystem {
 
 	void registerComponentType(ComponentType ct, int capacity) {
 		int index = ct.getIndex();
-		ComponentMapper mapper = new ComponentMapper(ct.getType(), world);
+		ComponentMapper mapper = instanceOfComponentMapper(ct.getType());
 		mapper.components.ensureCapacity(capacity);
 		mappers.set(index, mapper);
 	}
 
-	@SuppressWarnings("unchecked")
+	protected <T extends Component> ComponentMapper<T> instanceOfComponentMapper(Class<T> type) {
+		return new ComponentMapper<>(type, world);
+	}
+
 	static <T extends Component> T newInstance(Class<T> componentClass) {
 		try {
 			return ClassReflection.newInstance(componentClass);

--- a/artemis-backend-gwt/artemis-gwt/src/main/resources/com/artemis/gwtref/ArtemisReflect.gwt.xml
+++ b/artemis-backend-gwt/artemis-gwt/src/main/resources/com/artemis/gwtref/ArtemisReflect.gwt.xml
@@ -57,7 +57,9 @@
     <extend-configuration-property name="artemis.reflect.include" value="com.artemis.injection.WiredFieldResolver"/>
     <extend-configuration-property name="artemis.reflect.include" value="com.artemis.injection.AspectFieldResolver"/>
     <extend-configuration-property name="artemis.reflect.include" value="com.artemis.injection.PojoFieldResolver"/>
+    <extend-configuration-property name="artemis.reflect.include" value="com.artemis.ArtemisPhaseListener"/>
     <extend-configuration-property name="artemis.reflect.include" value="com.artemis.utils.BitVector"/>
+
 
     <source path="">
         <exclude name="**/gen/**"/>

--- a/artemis-core/artemis/src/main/java/com/artemis/ArtemisPhaseListener.java
+++ b/artemis-core/artemis/src/main/java/com/artemis/ArtemisPhaseListener.java
@@ -14,5 +14,5 @@ public interface ArtemisPhaseListener {
         POST_DISPOSE;
     }
 
-    void onPhase(Phase phase);
+    void onPhase(World w, Phase phase);
 }

--- a/artemis-core/artemis/src/main/java/com/artemis/ArtemisPhaseListener.java
+++ b/artemis-core/artemis/src/main/java/com/artemis/ArtemisPhaseListener.java
@@ -1,0 +1,18 @@
+package com.artemis;
+
+/**
+ * Phase listener for artemis lifecycle events.
+ *
+ * @author Daan van Yperen
+ */
+public interface ArtemisPhaseListener {
+
+    enum Phase {
+        PRE_INITIALIZE,
+        POST_INITIALIZE,
+        PRE_DISPOSE,
+        POST_DISPOSE;
+    }
+
+    void onPhase(Phase phase);
+}

--- a/artemis-core/artemis/src/main/java/com/artemis/BatchChangeProcessor.java
+++ b/artemis-core/artemis/src/main/java/com/artemis/BatchChangeProcessor.java
@@ -5,7 +5,7 @@ import com.artemis.utils.IntBag;
 
 import com.artemis.utils.BitVector;
 
-final class BatchChangeProcessor {
+class BatchChangeProcessor {
 	private final World world;
 	private final AspectSubscriptionManager asm;
 

--- a/artemis-core/artemis/src/main/java/com/artemis/ComponentManager.java
+++ b/artemis-core/artemis/src/main/java/com/artemis/ComponentManager.java
@@ -60,12 +60,16 @@ public class ComponentManager extends BaseSystem {
 
 	void registerComponentType(ComponentType ct, int capacity) {
 		int index = ct.getIndex();
-		ComponentMapper mapper = new ComponentMapper(ct.getType(), world);
+		ComponentMapper mapper = instanceOfComponentMapper(ct.getType());
 		mapper.components.ensureCapacity(capacity);
 		mappers.set(index, mapper);
 	}
 
-	@SuppressWarnings("unchecked")
+	/** Create new instance of component mapper */
+    protected <T extends Component> ComponentMapper<T> instanceOfComponentMapper(Class<T> type) {
+        return new ComponentMapper<>(type, world);
+    }
+
 	static <T extends Component> T newInstance(Class<T> componentClass) {
 		try {
 			return ClassReflection.newInstance(componentClass);

--- a/artemis-core/artemis/src/main/java/com/artemis/InternalFactory.java
+++ b/artemis-core/artemis/src/main/java/com/artemis/InternalFactory.java
@@ -1,0 +1,38 @@
+package com.artemis;
+
+import com.artemis.annotations.UnstableApi;
+import sun.reflect.generics.reflectiveObjects.NotImplementedException;
+
+/**
+ * Produces internal classes.
+ * <p>
+ * Some provided classes are considered internal implementations and no guarantees are given,..
+ * <p>
+ * Overriding the internal factory is not recommended that depend greatly on implementation details to begin
+ * with, like debuggers and editors.
+ *
+ * @author Daan van Yperen
+ */
+@UnstableApi
+class InternalFactory {
+    InternalFactory() {
+        // implemented as a class to force package-locality.
+    }
+
+    ComponentManager createComponentManager(int expectedEntityCount) {
+        throw new RuntimeException();
+    }
+
+    EntityManager createEntityManager(int expectedEntityCount) {
+        throw new RuntimeException();
+    }
+
+    AspectSubscriptionManager createSubscriptionManager() {
+        throw new RuntimeException();
+    }
+
+    BatchChangeProcessor createBatchChangeProcessor(World w) {
+        throw new RuntimeException();
+    }
+
+}

--- a/artemis-core/artemis/src/main/java/com/artemis/InternalFactoryImpl.java
+++ b/artemis-core/artemis/src/main/java/com/artemis/InternalFactoryImpl.java
@@ -1,0 +1,32 @@
+package com.artemis;
+
+/**
+ * Default implementation of the internal factory.
+ *
+ * Overriding the internal factory is not recommended that depend greatly on implementation details to begin
+ * with, like debuggers and editors.
+ *
+ * @author Daan van Yperen
+ * @see InternalFactory
+ */
+class InternalFactoryImpl extends InternalFactory {
+    @Override
+    ComponentManager createComponentManager(int expectedEntityCount) {
+        return new ComponentManager(expectedEntityCount);
+    }
+
+    @Override
+    EntityManager createEntityManager(int expectedEntityCount) {
+        return new EntityManager(expectedEntityCount);
+    }
+
+    @Override
+    AspectSubscriptionManager createSubscriptionManager() {
+        return new AspectSubscriptionManager();
+    }
+
+    @Override
+    BatchChangeProcessor createBatchChangeProcessor(World w) {
+        return new BatchChangeProcessor(w);
+    }
+}

--- a/artemis-core/artemis/src/main/java/com/artemis/World.java
+++ b/artemis-core/artemis/src/main/java/com/artemis/World.java
@@ -5,6 +5,7 @@ import com.artemis.injection.Injector;
 import com.artemis.utils.Bag;
 import com.artemis.utils.ImmutableBag;
 import com.artemis.utils.IntBag;
+import com.artemis.utils.InterfaceUtil;
 
 import java.util.*;
 
@@ -19,431 +20,474 @@ import static com.artemis.WorldConfiguration.ENTITY_MANAGER_IDX;
  * retrieve entities. It is also important to set the delta each game loop
  * iteration, and initialize before game loop.
  * </p>
+ *
  * @author Arni Arent
  * @author junkdog
  */
 public class World {
 
-	/** Manages all entities for the world. */
-	private final EntityManager em;
+    /**
+     * Manages all entities for the world.
+     */
+    private final EntityManager em;
 
-	/** Manages all component-entity associations for the world. */
-	private final ComponentManager cm;
+    /**
+     * Manages all component-entity associations for the world.
+     */
+    private final ComponentManager cm;
 
-	/** Pool of entity edits. */
-	final BatchChangeProcessor batchProcessor;
+    /**
+     * Pool of entity edits.
+     */
+    final BatchChangeProcessor batchProcessor;
 
-		/** Contains all systems unordered. */
-	final Bag<BaseSystem> systemsBag;
-	/** Manages all aspect based entity subscriptions for the world. */
-	final AspectSubscriptionManager asm;
+    /**
+     * Contains all systems unordered.
+     */
+    final Bag<BaseSystem> systemsBag;
+    /**
+     * Manages all aspect based entity subscriptions for the world.
+     */
+    final AspectSubscriptionManager asm;
 
-	/** Contains strategy for invoking systems upon process. */
-	SystemInvocationStrategy invocationStrategy;
+    final InternalFactory internalFactory;
 
-	final WorldSegment partition;
+    /**
+     * Contains strategy for invoking systems upon process.
+     */
+    SystemInvocationStrategy invocationStrategy;
 
-	/** The time passed since the last update. */
-	public float delta;
+    final WorldSegment partition;
 
-	final boolean alwaysDelayComponentRemoval;
+    /**
+     * The time passed since the last update.
+     */
+    public float delta;
 
-	/**
-	 * Creates a world without custom systems.
-	 * <p>
-	 * {@link com.artemis.EntityManager}, {@link ComponentManager} and {@link AspectSubscriptionManager} are
-	 * available by default.
-	 * </p>
-	 * Why are you using this? Use {@link #World(WorldConfiguration)} to create a world with your own systems.
-	 */
-	public World() {
-		this(new WorldConfiguration());
-	}
+    final boolean alwaysDelayComponentRemoval;
+    private ArtemisPhaseListener[] phaseListeners;
 
-	/**
-	 * Creates a new world.
-	 * <p>
-	 * {@link com.artemis.EntityManager}, {@link ComponentManager} and {@link AspectSubscriptionManager} are
-	 * available by default, on top of your own systems.
-	 * </p>
-	 * @see WorldConfigurationBuilder
-	 * @see WorldConfiguration
-	 */
-	public World(WorldConfiguration configuration) {
-		partition = new WorldSegment(configuration);
-		systemsBag = configuration.systems;
+    /**
+     * Creates a world without custom systems.
+     * <p>
+     * {@link com.artemis.EntityManager}, {@link ComponentManager} and {@link AspectSubscriptionManager} are
+     * available by default.
+     * </p>
+     * Why are you using this? Use {@link #World(WorldConfiguration)} to create a world with your own systems.
+     */
+    public World() {
+        this(new WorldConfiguration());
+    }
 
-		final ComponentManager lcm =
-			(ComponentManager) systemsBag.get(COMPONENT_MANAGER_IDX);
-		final EntityManager lem =
-			(EntityManager) systemsBag.get(ENTITY_MANAGER_IDX);
-		final AspectSubscriptionManager lasm =
-			(AspectSubscriptionManager) systemsBag.get(ASPECT_SUBSCRIPTION_MANAGER_IDX);
+    /**
+     * Creates a new world.
+     * <p>
+     * {@link com.artemis.EntityManager}, {@link ComponentManager} and {@link AspectSubscriptionManager} are
+     * available by default, on top of your own systems.
+     * </p>
+     *
+     * @see WorldConfigurationBuilder
+     * @see WorldConfiguration
+     */
+    public World(WorldConfiguration configuration) {
+        partition = new WorldSegment(configuration);
+        systemsBag = configuration.systems;
+        internalFactory = configuration.internalFactory;
 
-		cm = lcm == null ? new ComponentManager(configuration.expectedEntityCount()) : lcm;
-		em = lem == null ? new EntityManager(configuration.expectedEntityCount()) : lem;
-		asm = lasm == null ? new AspectSubscriptionManager() : lasm;
-		batchProcessor = new BatchChangeProcessor(this);
-		alwaysDelayComponentRemoval = configuration.isAlwaysDelayComponentRemoval();
+        final ComponentManager lcm =
+                (ComponentManager) systemsBag.get(COMPONENT_MANAGER_IDX);
+        final EntityManager lem =
+                (EntityManager) systemsBag.get(ENTITY_MANAGER_IDX);
+        final AspectSubscriptionManager lasm =
+                (AspectSubscriptionManager) systemsBag.get(ASPECT_SUBSCRIPTION_MANAGER_IDX);
 
-		configuration.initialize(this, partition.injector, asm);
-	}
+        phaseListeners = InterfaceUtil.getObjectsImplementing(systemsBag, ArtemisPhaseListener.class, new ArtemisPhaseListener[0]);
+        dispatchPhaseEvent(ArtemisPhaseListener.Phase.PRE_INITIALIZE);
 
-	/**
-	 * Inject dependencies on object.
-	 * <p/>
-	 * Immediately perform dependency injection on the target, even if the target isn't of an Artemis class.
-	 * <p/>
-	 * If you want to specify nonstandard dependencies to inject, use
-	 * {@link com.artemis.WorldConfiguration#register(String, Object)} instead, or
-	 * configure an {@link com.artemis.injection.Injector}
-	 * <p/>
-	 * If you want a non-throwing alternative, use {@link #inject(Object, boolean)}
-	 * @param target
-	 * 		Object to inject into.
-	 * 		throws {@link MundaneWireException} if {@code target} is annotated with {@link com.artemis.annotations.SkipWire}
-	 * @see com.artemis.annotations.Wire for more details about dependency injection.
-	 * @see #inject(Object, boolean)
-	 */
-	public void inject(Object target) {
-		inject(target, true);
-	}
+        cm = lcm == null ? internalFactory.createComponentManager(configuration.expectedEntityCount()) : lcm;
+        em = lem == null ? internalFactory.createEntityManager(configuration.expectedEntityCount()) : lem;
+        asm = lasm == null ? internalFactory.createSubscriptionManager() : lasm;
+        batchProcessor = internalFactory.createBatchChangeProcessor(this);
+        alwaysDelayComponentRemoval = configuration.isAlwaysDelayComponentRemoval();
 
-	/**
-	 * Inject dependencies on object.
-	 * <p/>
-	 * Will not if it is annotated with {@link com.artemis.annotations.Wire}.
-	 * <p/>
-	 * If you want to specify nonstandard dependencies to inject, use
-	 * {@link com.artemis.WorldConfiguration#register(String, Object)} instead, or
-	 * configure an {@link com.artemis.injection.Injector}.
-	 * @param target
-	 * 		Object to inject into.
-	 * @param failIfNotInjectable
-	 * 		if true, this method will
-	 * 		throws {@link MundaneWireException} if {@code target} is annotated with
-	 * 		{@link com.artemis.annotations.SkipWire} and {@code failIfNotInjectable} is true
-	 * @see com.artemis.annotations.Wire for more details about dependency injection.
-	 * @see #inject(Object)
-	 */
-	public void inject(Object target, boolean failIfNotInjectable) {
-		boolean injectable = partition.injector.isInjectable(target);
-		if (!injectable && failIfNotInjectable)
-			throw new MundaneWireException("Attempted injection on " + target.getClass()
-					.getName() + ", which is annotated with @SkipWire");
+        configuration.initialize(this, partition.injector, asm);
 
-		if (injectable)
-			partition.injector.inject(target);
-	}
+        dispatchPhaseEvent(ArtemisPhaseListener.Phase.POST_INITIALIZE);
+    }
 
-	public <T> T getRegistered(String name) {
-		return partition.injector.getRegistered(name);
-	}
+    /** Trigger phase listener on all interested systems. */
+    private void dispatchPhaseEvent(ArtemisPhaseListener.Phase phase) {
+        if ( phaseListeners != null ) {
+            for (ArtemisPhaseListener listener : phaseListeners) {
+                listener.onPhase(phase);
+            }
+        }
+    }
 
-	public <T> T getRegistered(Class<T> type) {
-		return partition.injector.getRegistered(type);
-	}
+    /**
+     * Inject dependencies on object.
+     * <p/>
+     * Immediately perform dependency injection on the target, even if the target isn't of an Artemis class.
+     * <p/>
+     * If you want to specify nonstandard dependencies to inject, use
+     * {@link com.artemis.WorldConfiguration#register(String, Object)} instead, or
+     * configure an {@link com.artemis.injection.Injector}
+     * <p/>
+     * If you want a non-throwing alternative, use {@link #inject(Object, boolean)}
+     *
+     * @param target Object to inject into.
+     *               throws {@link MundaneWireException} if {@code target} is annotated with {@link com.artemis.annotations.SkipWire}
+     * @see com.artemis.annotations.Wire for more details about dependency injection.
+     * @see #inject(Object, boolean)
+     */
+    public void inject(Object target) {
+        inject(target, true);
+    }
 
-	/**
-	 * Disposes all systems. Only necessary if either need to free
-	 * managed resources upon bringing the world to an end.
-	 * @throws ArtemisMultiException
-	 * 		if any system throws an exception.
-	 */
-	public void dispose() {
-		List<Throwable> exceptions = new ArrayList<Throwable>();
+    /**
+     * Inject dependencies on object.
+     * <p/>
+     * Will not if it is annotated with {@link com.artemis.annotations.Wire}.
+     * <p/>
+     * If you want to specify nonstandard dependencies to inject, use
+     * {@link com.artemis.WorldConfiguration#register(String, Object)} instead, or
+     * configure an {@link com.artemis.injection.Injector}.
+     *
+     * @param target              Object to inject into.
+     * @param failIfNotInjectable if true, this method will
+     *                            throws {@link MundaneWireException} if {@code target} is annotated with
+     *                            {@link com.artemis.annotations.SkipWire} and {@code failIfNotInjectable} is true
+     * @see com.artemis.annotations.Wire for more details about dependency injection.
+     * @see #inject(Object)
+     */
+    public void inject(Object target, boolean failIfNotInjectable) {
+        boolean injectable = partition.injector.isInjectable(target);
+        if (!injectable && failIfNotInjectable)
+            throw new MundaneWireException("Attempted injection on " + target.getClass()
+                    .getName() + ", which is annotated with @SkipWire");
 
-		for (BaseSystem system : systemsBag) {
-			try {
-				system.dispose();
-			} catch (Exception e) {
-				exceptions.add(e);
-			}
-		}
+        if (injectable)
+            partition.injector.inject(target);
+    }
 
-		if (exceptions.size() > 0)
-			throw new ArtemisMultiException(exceptions);
-	}
+    public <T> T getRegistered(String name) {
+        return partition.injector.getRegistered(name);
+    }
 
-	/**
-	 * Get entity editor for entity.
-	 * @return a fast albeit verbose editor to perform batch changes to entities.
-	 * @param entityId entity to fetch editor for.
-	 */
-	public EntityEdit edit(int entityId) {
-		if (!em.isActive(entityId))
-			throw new RuntimeException("Issued edit on deleted " + entityId);
+    public <T> T getRegistered(Class<T> type) {
+        return partition.injector.getRegistered(type);
+    }
 
-		return batchProcessor.obtainEditor(entityId);
-	}
+    /**
+     * Disposes all systems. Only necessary if either need to free
+     * managed resources upon bringing the world to an end.
+     *
+     * @throws ArtemisMultiException if any system throws an exception.
+     */
+    public void dispose() {
+        dispatchPhaseEvent(ArtemisPhaseListener.Phase.PRE_DISPOSE);
 
-	/**
-	 * Gets the <code>composition id</code> uniquely identifying the
-	 * component composition of an entity. Each composition identity maps
-	 * to one unique <code>BitVector</code>.
-	 *
-	 * @param entityId Entity for which to get the composition id
-	 * @return composition identity of entity
-	 */
-	public int compositionId(int entityId) {
-		return cm.getIdentity(entityId);
-	}
+        List<Throwable> exceptions = new ArrayList<Throwable>();
 
-	/**
-	 * Returns a manager that takes care of all the entities in the world.
-	 * @return entity manager
-	 */
-	public EntityManager getEntityManager() {
-		return em;
-	}
+        for (BaseSystem system : systemsBag) {
+            try {
+                system.dispose();
+            } catch (Exception e) {
+                exceptions.add(e);
+            }
+        }
 
-	/**
-	 * Returns a manager that takes care of all the components in the world.
-	 * @return component manager
-	 */
-	public ComponentManager getComponentManager() {
-		return cm;
-	}
+        if (exceptions.size() > 0)
+            throw new ArtemisMultiException(exceptions);
 
-	/**
-	 * Returns the manager responsible for creating and maintaining
-	 * {@link EntitySubscription subscriptions} in the world.
-	 *
-	 * @return aspect subscription manager
-	 */
-	public AspectSubscriptionManager getAspectSubscriptionManager() {
-		return asm;
-	}
+        dispatchPhaseEvent(ArtemisPhaseListener.Phase.POST_DISPOSE);
+    }
 
-	/**
-	 * Time since last game loop.
-	 * @return delta time since last game loop
-	 */
-	public float getDelta() {
-		return delta;
-	}
+    /**
+     * Get entity editor for entity.
+     *
+     * @param entityId entity to fetch editor for.
+     * @return a fast albeit verbose editor to perform batch changes to entities.
+     */
+    public EntityEdit edit(int entityId) {
+        if (!em.isActive(entityId))
+            throw new RuntimeException("Issued edit on deleted " + entityId);
 
-	/**
-	 * You must specify the delta for the game here.
-	 * @param delta
-	 * 		time since last game loop
-	 */
-	public void setDelta(float delta) {
-		this.delta = delta;
-	}
+        return batchProcessor.obtainEditor(entityId);
+    }
 
-	/**
-	 * Delete the entity from the world.
-	 * @param e
-	 * 		the entity to delete
-	 * @see #delete(int) recommended alternative.
-	 */
-	public void deleteEntity(Entity e) {
-		delete(e.id);
-	}
+    /**
+     * Gets the <code>composition id</code> uniquely identifying the
+     * component composition of an entity. Each composition identity maps
+     * to one unique <code>BitVector</code>.
+     *
+     * @param entityId Entity for which to get the composition id
+     * @return composition identity of entity
+     */
+    public int compositionId(int entityId) {
+        return cm.getIdentity(entityId);
+    }
 
-	/**
-	 * Delete the entity from the world.
-	 *
-	 * The entity is considered to be in a final state once invoked;
-	 * adding or removing components from an entity scheduled for
-	 * deletion will likely throw exceptions.
-	 *
-	 * @param entityId
-	 * 		the entity to delete
-	 */
-	public void delete(int entityId) {
-		batchProcessor.delete(entityId);
-	}
+    /**
+     * Returns a manager that takes care of all the entities in the world.
+     *
+     * @return entity manager
+     */
+    public EntityManager getEntityManager() {
+        return em;
+    }
 
-	/**
-	 * Create and return a new or reused entity instance. Entity is
-	 * automatically added to the world.
-	 *
-	 * @return entity
-	 * @see #create() recommended alternative.
-	 */
-	public Entity createEntity() {
-		Entity e = em.createEntityInstance();
-		batchProcessor.changed.unsafeSet(e.getId());
-		return e;
-	}
+    /**
+     * Returns a manager that takes care of all the components in the world.
+     *
+     * @return component manager
+     */
+    public ComponentManager getComponentManager() {
+        return cm;
+    }
 
-	/**
-	 * Create and return a new or reused entity id. Entity is
-	 * automatically added to the world.
-	 *
-	 * @return assigned entity id, where id >= 0.
-	 */
-	public int create() {
-		int entityId = em.create();
-		batchProcessor.changed.unsafeSet(entityId);
-		return entityId;
-	}
+    /**
+     * Returns the manager responsible for creating and maintaining
+     * {@link EntitySubscription subscriptions} in the world.
+     *
+     * @return aspect subscription manager
+     */
+    public AspectSubscriptionManager getAspectSubscriptionManager() {
+        return asm;
+    }
 
-	/**
-	 * Create and return an {@link Entity} wrapping a new or reused entity instance.
-	 * Entity is automatically added to the world.
-	 *
-	 * Use {@link Entity#edit()} to set up your newly created entity.
-	 *
-	 * You can also create entities using:
-	 * <ul>
-	 *   <li>{@link com.artemis.utils.EntityBuilder} Convenient entity creation. Not useful when pooling.</li>
-	 *   <li>{@link com.artemis.Archetype} Fastest, low level, no parameterized components.</li>
-	 *   <li><a href="https://github.com/junkdog/artemis-odb/wiki/Serialization">Serialization</a>,
-	 *        with a simple prefab-like class to parameterize the entities.</li>
-	 * </ul>
-	 *
-	 * @see #create() recommended alternative.
-	 * @return entity
-	 */
-	public Entity createEntity(Archetype archetype) {
-		Entity e = em.createEntityInstance();
+    /**
+     * Time since last game loop.
+     *
+     * @return delta time since last game loop
+     */
+    public float getDelta() {
+        return delta;
+    }
 
-		int id = e.getId();
-		archetype.transmuter.perform(id);
-		cm.setIdentity(e.id, archetype.compositionId);
+    /**
+     * You must specify the delta for the game here.
+     *
+     * @param delta time since last game loop
+     */
+    public void setDelta(float delta) {
+        this.delta = delta;
+    }
 
-		batchProcessor.changed.unsafeSet(id);
+    /**
+     * Delete the entity from the world.
+     *
+     * @param e the entity to delete
+     * @see #delete(int) recommended alternative.
+     */
+    public void deleteEntity(Entity e) {
+        delete(e.id);
+    }
 
-		return e;
-	}
+    /**
+     * Delete the entity from the world.
+     * <p>
+     * The entity is considered to be in a final state once invoked;
+     * adding or removing components from an entity scheduled for
+     * deletion will likely throw exceptions.
+     *
+     * @param entityId the entity to delete
+     */
+    public void delete(int entityId) {
+        batchProcessor.delete(entityId);
+    }
 
-	/**
-	 * Create and return an {@link Entity} wrapping a new or reused entity instance.
-	 * Entity is automatically added to the world.
-	 *
-	 * Use {@link Entity#edit()} to set up your newly created entity.
-	 *
-	 * You can also create entities using:
-	 * - {@link com.artemis.utils.EntityBuilder} Convenient entity creation. Not useful when pooling.
-	 * - {@link com.artemis.Archetype} Fastest, low level, no parameterized components.
-	 *
-	 * @return assigned entity id
-	 */
-	public int create(Archetype archetype) {
-		int entityId = em.create();
+    /**
+     * Create and return a new or reused entity instance. Entity is
+     * automatically added to the world.
+     *
+     * @return entity
+     * @see #create() recommended alternative.
+     */
+    public Entity createEntity() {
+        Entity e = em.createEntityInstance();
+        batchProcessor.changed.unsafeSet(e.getId());
+        return e;
+    }
 
-		archetype.transmuter.perform(entityId);
-		cm.setIdentity(entityId, archetype.compositionId);
+    /**
+     * Create and return a new or reused entity id. Entity is
+     * automatically added to the world.
+     *
+     * @return assigned entity id, where id >= 0.
+     */
+    public int create() {
+        int entityId = em.create();
+        batchProcessor.changed.unsafeSet(entityId);
+        return entityId;
+    }
 
-		batchProcessor.changed.unsafeSet(entityId);
+    /**
+     * Create and return an {@link Entity} wrapping a new or reused entity instance.
+     * Entity is automatically added to the world.
+     * <p>
+     * Use {@link Entity#edit()} to set up your newly created entity.
+     * <p>
+     * You can also create entities using:
+     * <ul>
+     * <li>{@link com.artemis.utils.EntityBuilder} Convenient entity creation. Not useful when pooling.</li>
+     * <li>{@link com.artemis.Archetype} Fastest, low level, no parameterized components.</li>
+     * <li><a href="https://github.com/junkdog/artemis-odb/wiki/Serialization">Serialization</a>,
+     * with a simple prefab-like class to parameterize the entities.</li>
+     * </ul>
+     *
+     * @return entity
+     * @see #create() recommended alternative.
+     */
+    public Entity createEntity(Archetype archetype) {
+        Entity e = em.createEntityInstance();
 
-		return entityId;
-	}
+        int id = e.getId();
+        archetype.transmuter.perform(id);
+        cm.setIdentity(e.id, archetype.compositionId);
 
-	/**
-	 * Get entity with the specified id.
-	 *
-	 * Resolves entity id to the unique entity instance. <em>This method may
-	 * return an entity even if it isn't active in the world.</em> Make sure to
-	 * not retain id's of deleted entities.
-	 *
-	 * @param entityId
-	 * 		the entities id
-	 * @return the specific entity
-	 */
-	public Entity getEntity(int entityId) {
-		return em.getEntity(entityId);
-	}
+        batchProcessor.changed.unsafeSet(id);
 
-	/**
-	 * Gives you all the systems in this world for possible iteration.
-	 * @return all entity systems in world
-	 */
-	public ImmutableBag<BaseSystem> getSystems() {
-		return systemsBag;
-	}
+        return e;
+    }
 
-	/**
-	 * Retrieve a system for specified system type.
-	 * @param <T>
-	 * 		the class type of system
-	 * @param type
-	 * 		type of system
-	 * @return instance of the system in this world
-	 */
-	@SuppressWarnings("unchecked")
-	public <T extends BaseSystem> T getSystem(Class<T> type) {
-		return (T) partition.systems.get(type);
-	}
+    /**
+     * Create and return an {@link Entity} wrapping a new or reused entity instance.
+     * Entity is automatically added to the world.
+     * <p>
+     * Use {@link Entity#edit()} to set up your newly created entity.
+     * <p>
+     * You can also create entities using:
+     * - {@link com.artemis.utils.EntityBuilder} Convenient entity creation. Not useful when pooling.
+     * - {@link com.artemis.Archetype} Fastest, low level, no parameterized components.
+     *
+     * @return assigned entity id
+     */
+    public int create(Archetype archetype) {
+        int entityId = em.create();
 
-	/** Set strategy for invoking systems on {@link #process()}. */
-	protected void setInvocationStrategy(SystemInvocationStrategy invocationStrategy) {
-		this.invocationStrategy = invocationStrategy;
-		invocationStrategy.setWorld(this);
-		invocationStrategy.setSystems(systemsBag);
-		invocationStrategy.initialize();
-	}
+        archetype.transmuter.perform(entityId);
+        cm.setIdentity(entityId, archetype.compositionId);
 
-	/**
-	 * Process all non-passive systems.
-	 * @see InvocationStrategy to control and extend how systems are invoked.
-	 */
-	public void process() {
-		invocationStrategy.process();
+        batchProcessor.changed.unsafeSet(entityId);
 
-		IntBag pendingPurge = batchProcessor.getPendingPurge();
-		if (!pendingPurge.isEmpty()) {
-			cm.clean(pendingPurge);
-			em.clean(pendingPurge);
+        return entityId;
+    }
 
-			batchProcessor.purgeComponents();
-		}
-	}
+    /**
+     * Get entity with the specified id.
+     * <p>
+     * Resolves entity id to the unique entity instance. <em>This method may
+     * return an entity even if it isn't active in the world.</em> Make sure to
+     * not retain id's of deleted entities.
+     *
+     * @param entityId the entities id
+     * @return the specific entity
+     */
+    public Entity getEntity(int entityId) {
+        return em.getEntity(entityId);
+    }
 
-	/**
-	 * Retrieves a ComponentMapper instance for fast retrieval of components
-	 * from entities.
-	 *
-	 * Odb automatically injects component mappers into systems, calling this
-	 * method is usually not required.,
-	 *
-	 * @param <T>
-	 * 		class type of the component
-	 * @param type
-	 * 		type of component to get mapper for
-	 * @return mapper for specified component type
-	 */
-	public <T extends Component> ComponentMapper<T> getMapper(Class<T> type) {
-		return cm.getMapper(type);
-	}
+    /**
+     * Gives you all the systems in this world for possible iteration.
+     *
+     * @return all entity systems in world
+     */
+    public ImmutableBag<BaseSystem> getSystems() {
+        return systemsBag;
+    }
 
-	/**
-	 * @return Injector responsible for dependency injection.
-	 */
-	public Injector getInjector() {
-		return partition.injector;
-	}
+    /**
+     * Retrieve a system for specified system type.
+     *
+     * @param <T>  the class type of system
+     * @param type type of system
+     * @return instance of the system in this world
+     */
+    @SuppressWarnings("unchecked")
+    public <T extends BaseSystem> T getSystem(Class<T> type) {
+        return (T) partition.systems.get(type);
+    }
 
-	/**
-	 * @return Strategy used for invoking systems during {@link World#process()}.
-	 */
-	public <T extends SystemInvocationStrategy> T getInvocationStrategy() {
-		return (T) invocationStrategy;
-	}
+    /**
+     * Set strategy for invoking systems on {@link #process()}.
+     */
+    protected void setInvocationStrategy(SystemInvocationStrategy invocationStrategy) {
+        this.invocationStrategy = invocationStrategy;
+        invocationStrategy.setWorld(this);
+        invocationStrategy.setSystems(systemsBag);
+        invocationStrategy.initialize();
+    }
 
-	static class WorldSegment {
-		/** Contains all systems and systems classes mapped. */
-		final Map<Class<?>, BaseSystem> systems;
+    /**
+     * Process all non-passive systems.
+     *
+     * @see InvocationStrategy to control and extend how systems are invoked.
+     */
+    public void process() {
+        invocationStrategy.process();
+        IntBag pendingPurge = batchProcessor.getPendingPurge();
+        if (!pendingPurge.isEmpty()) {
+            cm.clean(pendingPurge);
+            em.clean(pendingPurge);
 
-		/** Responsible for dependency injection. */
-		final Injector injector;
+            batchProcessor.purgeComponents();
+        }
+    }
 
-		WorldSegment(WorldConfiguration configuration) {
-			systems = new IdentityHashMap<Class<?>, BaseSystem>();
-			injector = (configuration.injector != null)
-				? configuration.injector
-				: new CachedInjector();
-		}
-	}
+    /**
+     * Retrieves a ComponentMapper instance for fast retrieval of components
+     * from entities.
+     * <p>
+     * Odb automatically injects component mappers into systems, calling this
+     * method is usually not required.,
+     *
+     * @param <T>  class type of the component
+     * @param type type of component to get mapper for
+     * @return mapper for specified component type
+     */
+    public <T extends Component> ComponentMapper<T> getMapper(Class<T> type) {
+        return cm.getMapper(type);
+    }
+
+    /**
+     * @return Injector responsible for dependency injection.
+     */
+    public Injector getInjector() {
+        return partition.injector;
+    }
+
+    /**
+     * @return Strategy used for invoking systems during {@link World#process()}.
+     */
+    public <T extends SystemInvocationStrategy> T getInvocationStrategy() {
+        return (T) invocationStrategy;
+    }
+
+    static class WorldSegment {
+        /**
+         * Contains all systems and systems classes mapped.
+         */
+        final Map<Class<?>, BaseSystem> systems;
+
+        /**
+         * Responsible for dependency injection.
+         */
+        final Injector injector;
+
+        WorldSegment(WorldConfiguration configuration) {
+            systems = new IdentityHashMap<Class<?>, BaseSystem>();
+            injector = (configuration.injector != null)
+                    ? configuration.injector
+                    : new CachedInjector();
+        }
+    }
 
     /**
      * When true, component removal is delayed for all components until all subscriptions have been notified.
-	 *
-	 * @see WorldConfiguration#setAlwaysDelayComponentRemoval(boolean)
-	 * @see WorldConfigurationBuilder#alwaysDelayComponentRemoval(boolean)
+     *
+     * @see WorldConfiguration#setAlwaysDelayComponentRemoval(boolean)
+     * @see WorldConfigurationBuilder#alwaysDelayComponentRemoval(boolean)
      */
     public boolean isAlwaysDelayComponentRemoval() {
         return alwaysDelayComponentRemoval;

--- a/artemis-core/artemis/src/main/java/com/artemis/World.java
+++ b/artemis-core/artemis/src/main/java/com/artemis/World.java
@@ -119,7 +119,7 @@ public class World {
     private void dispatchPhaseEvent(ArtemisPhaseListener.Phase phase) {
         if ( phaseListeners != null ) {
             for (ArtemisPhaseListener listener : phaseListeners) {
-                listener.onPhase(phase);
+                listener.onPhase(this, phase);
             }
         }
     }

--- a/artemis-core/artemis/src/main/java/com/artemis/WorldConfiguration.java
+++ b/artemis-core/artemis/src/main/java/com/artemis/WorldConfiguration.java
@@ -1,6 +1,5 @@
 package com.artemis;
 
-import com.artemis.annotations.UnstableApi;
 import com.artemis.injection.Injector;
 import com.artemis.utils.Bag;
 import com.artemis.utils.BitVector;
@@ -35,6 +34,7 @@ public final class WorldConfiguration {
 
 	protected Injector injector;
 	protected SystemInvocationStrategy invocationStrategy;
+	protected InternalFactory internalFactory = new InternalFactoryImpl();
 
 	private boolean alwaysDelayComponentRemoval = false;
 	private Set<Class<? extends BaseSystem>> registered = new HashSet<Class<? extends BaseSystem>>();
@@ -75,6 +75,8 @@ public final class WorldConfiguration {
 		return this;
 	}
 
+
+
 	/**
 	 * Set strategy for invoking systems on {@link World#process()}.
 	 * @param invocationStrategy Strategy that will invoke systems.
@@ -102,6 +104,24 @@ public final class WorldConfiguration {
 	 */
 	public WorldConfiguration register(Object o) {
 		return register(o.getClass().getName(), o);
+	}
+
+    /**
+     * Get the factory for internal odb classes.
+     */
+	InternalFactory getInternalFactory() {
+		return internalFactory;
+	}
+
+    /**
+     * Replace the default factory for internal odb classes with your own.
+     *
+     * This is meant for extensions like debuggers and editors that need
+     * to hook into odb's implementation lifecycle. As such is very
+     * volatile. Avoid using this for games!
+     */
+	void setInternalFactory(InternalFactory internalFactory) {
+		this.internalFactory = internalFactory;
 	}
 
 	/**

--- a/artemis-core/artemis/src/main/java/com/artemis/WorldConfigurationBuilder.java
+++ b/artemis-core/artemis/src/main/java/com/artemis/WorldConfigurationBuilder.java
@@ -28,6 +28,7 @@ public class WorldConfigurationBuilder {
     private ArtemisPlugin activePlugin;
     private final InjectionCache cache;
     private SystemInvocationStrategy invocationStrategy;
+    private InternalFactory internalFactory;
 
     public WorldConfigurationBuilder() {
         reset();
@@ -45,9 +46,17 @@ public class WorldConfigurationBuilder {
         registerSystems(config);
         registerFieldResolvers(config);
         registerInvocationStrategies(config);
+        registerInternalFactory(config);
         config.setAlwaysDelayComponentRemoval(alwaysDelayComponentRemoval);
         reset();
         return config;
+    }
+
+    /** Registers a custom internal factory for core (internal) classes of the engine. */
+    private void registerInternalFactory(WorldConfiguration config) {
+        if (internalFactory != null) {
+            config.setInternalFactory(internalFactory);
+        }
     }
 
     private void registerInvocationStrategies(WorldConfiguration config) {
@@ -108,6 +117,18 @@ public class WorldConfigurationBuilder {
         fieldResolvers = new Bag<>();
         plugins = new Bag<>();
         alwaysDelayComponentRemoval = false;
+    }
+
+    /**
+     * Replace the default factory for internal odb classes with your own.
+     *
+     * This is meant for extensions like debuggers and editors that need
+     * to hook into odb's implementation lifecycle. As such is very
+     * volatile. Avoid using this for games!
+     */
+    WorldConfigurationBuilder register(InternalFactory internalFactory) {
+        this.internalFactory = internalFactory;
+        return this;
     }
 
     /**

--- a/artemis-core/artemis/src/main/java/com/artemis/utils/InterfaceUtil.java
+++ b/artemis-core/artemis/src/main/java/com/artemis/utils/InterfaceUtil.java
@@ -1,0 +1,29 @@
+package com.artemis.utils;
+
+import com.artemis.utils.reflect.ClassReflection;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * @author Daan van Yperen
+ */
+public class InterfaceUtil {
+
+    /**
+     * @param objects systems available.
+     * @param clazz   implemented class.
+     * @return All systems that implement given class.
+     */
+    @SuppressWarnings("unchecked")
+    public static <T> T[] getObjectsImplementing(ImmutableBag objects, Class<T> clazz, T[] t) {
+        final List<T> list = new ArrayList<>();
+        for (Object o : objects) {
+            if (o != null && ClassReflection.isInstance(clazz, o)) {
+                list.add((T)o);
+            }
+        }
+        return !list.isEmpty() ? list.toArray(t) : t;
+    }
+
+}

--- a/artemis-core/artemis/src/test/java/com/artemis/WorldPhaseListenerTest.java
+++ b/artemis-core/artemis/src/test/java/com/artemis/WorldPhaseListenerTest.java
@@ -1,0 +1,50 @@
+package com.artemis;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.*;
+
+import java.util.Arrays;
+
+import static org.mockito.Mockito.times;
+
+/**
+ * @author Daan van Yperen
+ */
+public class WorldPhaseListenerTest {
+
+    abstract class PhaseTestSystem extends BaseSystem implements ArtemisPhaseListener {
+    }
+
+    ;
+
+    @Mock
+    PhaseTestSystem phaseTestSystem;
+
+    @Captor
+    ArgumentCaptor<ArtemisPhaseListener.Phase> phaseCaptor;
+
+
+    @Before
+    public void init() {
+        MockitoAnnotations.initMocks(this);
+    }
+
+    @Test
+    public void When_world_created_and_disposed_Should_call_phase_listener_phases() {
+        World world = new World(new WorldConfiguration().setSystem(phaseTestSystem));
+        world.process();
+        world.dispose();
+
+        Mockito.verify(phaseTestSystem, times(4)).onPhase(phaseCaptor.capture());
+
+        Assert.assertEquals(
+                Arrays.asList(ArtemisPhaseListener.Phase.PRE_INITIALIZE,
+                        ArtemisPhaseListener.Phase.POST_INITIALIZE,
+                        ArtemisPhaseListener.Phase.PRE_DISPOSE,
+                        ArtemisPhaseListener.Phase.POST_DISPOSE)
+                , phaseCaptor.getAllValues());
+    }
+
+}

--- a/artemis-core/artemis/src/test/java/com/artemis/WorldPhaseListenerTest.java
+++ b/artemis-core/artemis/src/test/java/com/artemis/WorldPhaseListenerTest.java
@@ -7,6 +7,7 @@ import org.mockito.*;
 
 import java.util.Arrays;
 
+import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.times;
 
 /**
@@ -37,7 +38,7 @@ public class WorldPhaseListenerTest {
         world.process();
         world.dispose();
 
-        Mockito.verify(phaseTestSystem, times(4)).onPhase(phaseCaptor.capture());
+        Mockito.verify(phaseTestSystem, times(4)).onPhase(any(World.class), phaseCaptor.capture());
 
         Assert.assertEquals(
                 Arrays.asList(ArtemisPhaseListener.Phase.PRE_INITIALIZE,


### PR DESCRIPTION
**Required extension points for debugger and editors plugins.**
- New (package local) extension point for debuggers and editors. (`InternalFactory`). Can be set in plugins via `WorldConfigurationBuilder`.
- New lifecycle phase listener for debuggers and editors (`ArtemisPhaseListener`). Captures pre/post init, pre/post destroy.
- Removes final from impl specific classes to make the debug plugin work as-is.  Keeps them package local.
- Makes some small changes to managers to make it easier to replace `ComponentMapper` creation via `ComponentManager` inheritance.

The #570 Grafting mechanic is planned to replace (part of?) the `InternalFactory`, I'd like to retain some of the small changes and the phase listener as we probably don't want to graft world itself.

@junkdog perhaps put the grafting in this branch?
