### PR TITLE
[Enhancement] To Archtype

### DIFF
--- a/artemis-backend-gwt/artemis-gwt/src/main/java/com/artemis/backends/gwt/emu/com/artemis/Archetype.java
+++ b/artemis-backend-gwt/artemis-gwt/src/main/java/com/artemis/backends/gwt/emu/com/artemis/Archetype.java
@@ -10,13 +10,16 @@ package com.artemis;
 public final class Archetype {
 	final EntityTransmuter.TransmuteOperation transmuter;
 	public final int compositionId;
+	public final String name;
 
 	/**
 	 * @param transmuter Desired composition of derived components.
 	 * @param compositionId uniquely identifies component composition.
+	 * @param name          uniquely identifies Archetype by name.
 	 */
-	public Archetype(EntityTransmuter.TransmuteOperation transmuter, int compositionId) {
+	public Archetype(EntityTransmuter.TransmuteOperation transmuter, int compositionId, String name) {
 		this.transmuter = transmuter;
 		this.compositionId = compositionId;
+		this.name = name;
 	}
 }

--- a/artemis-core/artemis/src/main/java/com/artemis/Archetype.java
+++ b/artemis-core/artemis/src/main/java/com/artemis/Archetype.java
@@ -11,13 +11,16 @@ package com.artemis;
 public final class Archetype {
     final EntityTransmuter.TransmuteOperation transmuter;
     public final int compositionId;
+    public final String name;
 
     /**
      * @param transmuter    Desired composition of derived components.
      * @param compositionId uniquely identifies component composition.
+     * @param name          uniquely identifies Archetype by name.
      */
-    Archetype(EntityTransmuter.TransmuteOperation transmuter, int compositionId) {
+    Archetype(EntityTransmuter.TransmuteOperation transmuter, int compositionId, String name) {
         this.transmuter = transmuter;
         this.compositionId = compositionId;
+        this.name = name;
     }
 }

--- a/artemis-core/artemis/src/main/java/com/artemis/ArchetypeBuilder.java
+++ b/artemis-core/artemis/src/main/java/com/artemis/ArchetypeBuilder.java
@@ -102,6 +102,17 @@ public class ArchetypeBuilder {
 	 * @return new Archetype based on current state
 	 */
 	public Archetype build(World world) {
+		return build(world, null);
+	}
+
+	/**
+	 * Create a new world specific instance of Archetype based on the current state.
+	 *
+	 * @param world applicable domain of the Archetype.
+	 * @param name  uniquely identifies Archetype by name. If null or empty == compisitionId
+	 * @return new Archetype based on current state
+	 */
+	public Archetype build(World world, String name) {
 		ComponentType[] types = resolveTypes(world);
 
 		ComponentManager cm = world.getComponentManager();
@@ -111,10 +122,13 @@ public class ArchetypeBuilder {
 		}
 
 		int compositionId = cm.compositionIdentity(bitset(types));
+		if(name == null || name.isEmpty()){
+			name = String.valueOf(compositionId);
+		}
 		TransmuteOperation operation =
 			new TransmuteOperation(compositionId, mappers, new ComponentMapper[0]);
 
-		return new Archetype(operation, compositionId);
+		return new Archetype(operation, compositionId, name);
 	}
 	
 	/** generate bitset mask of types. */


### PR DESCRIPTION
I think it would be very useful to have a method to identify or reference Archetypes by name. I have updated `Archetype` and `ArchetypeBuilder` to reflect `Archetype` new String field. If not provided or empty will default to composition id.

Will be using this to Map Archtypes by name into an editor, allowing entities to be listed by friendly name without having to write a bunch of code trying to wrap stuff.