### PR TITLE
[REFACTORING] Remove redundant throw clauses

### DIFF
--- a/artemis-build-tools/artemis-maven/src/main/java/com/artemis/ArtemisMaven.java
+++ b/artemis-build-tools/artemis-maven/src/main/java/com/artemis/ArtemisMaven.java
@@ -60,7 +60,7 @@ public class ArtemisMaven extends AbstractMojo {
 	private Log log = getLog();
 
 	@Override
-	public void execute() throws MojoExecutionException, MojoFailureException {
+	public void execute() {
 		if (!enableArtemisPlugin) {
 			getLog().info("Plugin disabled via 'enableArtemisPlugin' set to false.");
 			return;

--- a/artemis-build-tools/artemis-maven/src/main/java/com/artemis/ComponentMatrix.java
+++ b/artemis-build-tools/artemis-maven/src/main/java/com/artemis/ComponentMatrix.java
@@ -39,7 +39,7 @@ public class ComponentMatrix extends AbstractMojo {
 	private String name;
 	
 	@Override
-	public void execute() throws MojoExecutionException {
+	public void execute() {
 		List<URI> files = new ArrayList<URI>();
 		files.add(classDirectory.toURI());
 

--- a/artemis-build-tools/artemis-weaver/src/main/java/com/artemis/weaver/CallableTransmuter.java
+++ b/artemis-build-tools/artemis-weaver/src/main/java/com/artemis/weaver/CallableTransmuter.java
@@ -1,6 +1,5 @@
 package com.artemis.weaver;
 
-import java.io.IOException;
 import java.util.concurrent.Callable;
 
 abstract class CallableTransmuter<T> implements Callable<T> {
@@ -10,7 +9,7 @@ abstract class CallableTransmuter<T> implements Callable<T> {
 		this.file = file;
 	}
 
-	protected abstract T process(String file) throws IOException;
+	protected abstract T process(String file);
 
 	@Override
 	public final T call() throws Exception {

--- a/artemis-build-tools/artemis-weaver/src/main/java/com/artemis/weaver/ComponentTypeTransmuter.java
+++ b/artemis-build-tools/artemis-weaver/src/main/java/com/artemis/weaver/ComponentTypeTransmuter.java
@@ -1,7 +1,5 @@
 package com.artemis.weaver;
 
-import java.io.IOException;
-
 import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.ClassVisitor;
 import org.objectweb.asm.ClassWriter;
@@ -25,7 +23,7 @@ public class ComponentTypeTransmuter extends CallableTransmuter<Void> implements
 	}
 	
 	@Override
-	protected Void process(String file) throws IOException {
+	protected Void process(String file) {
 		cw = new ClassWriter(ClassWriter.COMPUTE_FRAMES);
 		ClassVisitor cv = cw;
 		

--- a/artemis-build-tools/artemis-weaver/src/main/java/com/artemis/weaver/EntityLinkGenerator.java
+++ b/artemis-build-tools/artemis-weaver/src/main/java/com/artemis/weaver/EntityLinkGenerator.java
@@ -8,7 +8,6 @@ import com.artemis.weaver.transplant.ClassTransplantVisitor;
 import com.artemis.weaver.transplant.MethodBodyTransplanter;
 import org.objectweb.asm.*;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -23,7 +22,7 @@ public class EntityLinkGenerator extends CallableTransmuter<Void> implements Opc
 	}
 	
 	@Override
-	protected Void process(String file) throws IOException {
+	protected Void process(String file) {
 		final List<FieldDescriptor> mutators = new ArrayList<FieldDescriptor>();
 		for (FieldDescriptor fd : meta.fields()) {
 			if (fd.entityLinkMutator != null) {

--- a/artemis-build-tools/artemis-weaver/src/main/java/com/artemis/weaver/OptimizationTransmuter.java
+++ b/artemis-build-tools/artemis-weaver/src/main/java/com/artemis/weaver/OptimizationTransmuter.java
@@ -9,8 +9,6 @@ import com.artemis.weaver.optimizer.OptimizingSystemWeaver;
 import com.artemis.weaver.transplant.ClassMethodTransplantAdapter;
 import org.objectweb.asm.*;
 
-import java.io.IOException;
-
 public class OptimizationTransmuter extends CallableTransmuter<Void> implements Opcodes {
 	private ClassMetadata meta;
 	private ClassReader cr;
@@ -23,7 +21,7 @@ public class OptimizationTransmuter extends CallableTransmuter<Void> implements 
 	}
 
 	@Override
-	protected Void process(String file) throws IOException {
+	protected Void process(String file) {
 		cw = new ClassWriter(ClassWriter.COMPUTE_FRAMES);
 		ClassVisitor cv = cw;
 

--- a/artemis-build-tools/artemis-weaver/src/main/java/com/artemis/weaver/ProfilerTransmuter.java
+++ b/artemis-build-tools/artemis-weaver/src/main/java/com/artemis/weaver/ProfilerTransmuter.java
@@ -1,8 +1,5 @@
 package com.artemis.weaver;
 
-import java.io.FileNotFoundException;
-import java.io.IOException;
-
 import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.ClassVisitor;
 import org.objectweb.asm.ClassWriter;
@@ -29,7 +26,7 @@ public class ProfilerTransmuter extends CallableTransmuter<Void> implements Opco
 	}
 	
 	@Override
-	protected Void process(String file) throws IOException {
+	protected Void process(String file) {
 		injectProfilerStubs(meta);
 		
 		ClassVisitor cv = new ProfileVisitor(cw, meta);

--- a/artemis-build-tools/artemis-weaver/src/test/java/com/artemis/EntitySystemOptimizerTest.java
+++ b/artemis-build-tools/artemis-weaver/src/test/java/com/artemis/EntitySystemOptimizerTest.java
@@ -53,7 +53,7 @@ public class EntitySystemOptimizerTest {
 	}
 
 	@Test
-	public void detect_preserve_process_visibility_test() throws Exception {
+	public void detect_preserve_process_visibility_test() {
 		assertEquals(SAFE, scan(SafeOptimizeSystem.class).sysetemOptimizable);
 		assertEquals(SAFE, scan(IteratingSafeOptimizeSystem.class).sysetemOptimizable);
 	}

--- a/artemis-build-tools/artemis-weaver/src/test/java/com/artemis/SystemOptimizerTest.java
+++ b/artemis-build-tools/artemis-weaver/src/test/java/com/artemis/SystemOptimizerTest.java
@@ -38,7 +38,7 @@ public class SystemOptimizerTest {
 	}
 	
 	@Test
-	public void detect_preserve_process_visibility_test() throws Exception {
+	public void detect_preserve_process_visibility_test() {
 		ClassMetadata meta = scan(IteratingSafeOptimizeSystem.class);
 		assertEquals(SAFE, meta.sysetemOptimizable); 
 	}

--- a/artemis-build-tools/artemis-weaver/src/test/java/com/artemis/weaver/EntityLinkGeneratorTest.java
+++ b/artemis-build-tools/artemis-weaver/src/test/java/com/artemis/weaver/EntityLinkGeneratorTest.java
@@ -6,10 +6,6 @@ import com.artemis.meta.ClassMetadata;
 import org.junit.Test;
 import org.objectweb.asm.ClassReader;
 
-import java.io.IOException;
-
-import static org.junit.Assert.*;
-
 public class EntityLinkGeneratorTest {
 	@Test
 	public void generate_entity_id_accessor() {
@@ -17,11 +13,6 @@ public class EntityLinkGeneratorTest {
 		ClassMetadata meta = Weaver.scan(EntityReferencing.class);
 		EntityLinkGenerator elg = new EntityLinkGenerator(null, cr, meta);
 
-		try {
-			elg.process("EntityReferencing.class");
-		} catch (IOException e) {
-			e.printStackTrace();
-			fail(e.getMessage());
-		}
+		elg.process("EntityReferencing.class");
 	}
 }

--- a/artemis-core/artemis-test/src/test/java/com/artemis/component/PolyConstructorTest.java
+++ b/artemis-core/artemis-test/src/test/java/com/artemis/component/PolyConstructorTest.java
@@ -11,7 +11,7 @@ import com.artemis.World;
 public class PolyConstructorTest {
 	
 	@Test @SuppressWarnings("static-method")
-	public void pooled_class_with_many_constructors() throws Exception {
+	public void pooled_class_with_many_constructors() {
 		World world = new World();
 
 		Entity e1 = world.createEntity();

--- a/artemis-core/artemis/src/main/java/com/artemis/BaseComponentMapper.java
+++ b/artemis-core/artemis/src/main/java/com/artemis/BaseComponentMapper.java
@@ -37,9 +37,9 @@ public abstract class BaseComponentMapper<A extends Component> {
 	 *
 	 * @param e the entity that should possess the component
 	 * @return the instance of the component.
-	 * @throws ArrayIndexOutOfBoundsException
+	 * @throws ArrayIndexOutOfBoundsException if the component was removed or never existed
 	 */
-	public A get(Entity e) throws ArrayIndexOutOfBoundsException {
+	public A get(Entity e) {
 		return get(e.getId());
 	}
 
@@ -57,17 +57,18 @@ public abstract class BaseComponentMapper<A extends Component> {
 	 *
 	 * @param entityId the entity that should possess the component
 	 * @return the instance of the component.
-	 * @throws ArrayIndexOutOfBoundsException
+	 * @throws ArrayIndexOutOfBoundsException if the component was removed or never existed
 	 */
-	public abstract A get(int entityId) throws ArrayIndexOutOfBoundsException;
+	public abstract A get(int entityId);
 
 	/**
 	 * Checks if the entity has this type of component.
 	 *
 	 * @param e the entity to check
 	 * @return true if the entity has this component type, false if it doesn't
+	 * @throws ArrayIndexOutOfBoundsException if the component was removed or never existed
 	 */
-	public boolean has(Entity e) throws ArrayIndexOutOfBoundsException {
+	public boolean has(Entity e) {
 		return has(e.getId());
 	}
 

--- a/artemis-core/artemis/src/main/java/com/artemis/ComponentMapper.java
+++ b/artemis-core/artemis/src/main/java/com/artemis/ComponentMapper.java
@@ -58,10 +58,10 @@ public class ComponentMapper<A extends Component> extends BaseComponentMapper<A>
      *
      * @param entityId the entity that should possess the component
      * @return the instance of the component.
-     * @throws ArrayIndexOutOfBoundsException
+     * @throws ArrayIndexOutOfBoundsException if the component was removed or never existed
      */
     @Override
-    public A get(int entityId) throws ArrayIndexOutOfBoundsException {
+    public A get(int entityId) {
         return components.get(entityId);
     }
 
@@ -73,6 +73,7 @@ public class ComponentMapper<A extends Component> extends BaseComponentMapper<A>
      *
      * @param entityId the id of entity to check
      * @return {@code true} if the entity has this component type, {@code false} if it doesn't (or if it is scheduled for delayed removal).
+     * @throws ArrayIndexOutOfBoundsException if the component was removed or never existed
      */
     @Override
     public boolean has(int entityId) {

--- a/artemis-core/artemis/src/main/java/com/artemis/utils/Bag.java
+++ b/artemis-core/artemis/src/main/java/com/artemis/utils/Bag.java
@@ -71,9 +71,10 @@ public class Bag<E> implements ImmutableBag<E> {
 	 *
 	 * @return element that was removed from the Bag
 	 *
-	 * @throws ArrayIndexOutOfBoundsException
+	 * @throws ArrayIndexOutOfBoundsException if the index is out of range
+	 *         ({@code index < 0 || index >= size()})
 	 */
-	public E remove(int index) throws ArrayIndexOutOfBoundsException {
+	public E remove(int index) {
 		E e = data[index]; // make copy of element to remove so it can be returned
 		data[index] = data[--size]; // overwrite item to remove with last element
 		data[size] = null; // null last element, so gc can do its work
@@ -187,10 +188,11 @@ public class Bag<E> implements ImmutableBag<E> {
 	 *
 	 * @return the element at the specified position in bag
 	 *
-	 * @throws ArrayIndexOutOfBoundsException
+	 * @throws ArrayIndexOutOfBoundsException if the index is out of range
+	 *         ({@code index < 0 || index >= size()})
 	 */
 	@Override
-	public E get(int index) throws ArrayIndexOutOfBoundsException {
+	public E get(int index) {
 		return data[index];
 	}
 
@@ -300,7 +302,7 @@ public class Bag<E> implements ImmutableBag<E> {
 		unsafeSet(index, e);
 	}
 
-	private void grow(int newCapacity) throws ArrayIndexOutOfBoundsException {
+	private void grow(int newCapacity) {
 		data = Arrays.copyOf(data, newCapacity);
 	}
 

--- a/artemis-core/artemis/src/main/java/com/artemis/utils/IntBag.java
+++ b/artemis-core/artemis/src/main/java/com/artemis/utils/IntBag.java
@@ -46,7 +46,7 @@ public class IntBag implements ImmutableIntBag {
 	 *
 	 * @return true, if value was removed
 	 */
-	public boolean removeValue(int value) throws ArrayIndexOutOfBoundsException {
+	public boolean removeValue(int value) {
 		int index = indexOf(value);
 		if (index > -1)
 			removeIndex(index);
@@ -67,10 +67,11 @@ public class IntBag implements ImmutableIntBag {
 	 * @return element that was removed from the Bag
 	 * @deprecated Call {@link #removeIndex(int)} instead. {@link #remove(int)} will be removed in 3.0 due to ambiguity.
 	 *
-	 * @throws ArrayIndexOutOfBoundsException
+	 * @throws ArrayIndexOutOfBoundsException if the index is out of range
+	 *         ({@code index < 0 || index >= size()})
 	 */
 	@Deprecated
-	public int remove(int index) throws ArrayIndexOutOfBoundsException {
+	public int remove(int index) {
 		int e = data[index]; // make copy of element to remove so it can be returned
 		data[index] = data[--size]; // overwrite item to remove with last element
 		data[size] = 0; // null last element, so gc can do its work
@@ -89,9 +90,10 @@ public class IntBag implements ImmutableIntBag {
 	 *
 	 * @return element that was removed from the Bag
 	 *
-	 * @throws ArrayIndexOutOfBoundsException
+	 * @throws ArrayIndexOutOfBoundsException if the index is out of range
+	 *         ({@code index < 0 || index >= size()})
 	 */
-	public int removeIndex(int index) throws ArrayIndexOutOfBoundsException {
+	public int removeIndex(int index) {
 		int e = data[index]; // make copy of element to remove so it can be returned
 		data[index] = data[--size]; // overwrite item to remove with last element
 		data[size] = 0; // null last element, so gc can do its work
@@ -140,9 +142,10 @@ public class IntBag implements ImmutableIntBag {
 	 *
 	 * @return the element at the specified position in bag
 	 *
-	 * @throws ArrayIndexOutOfBoundsException
+	 * @throws ArrayIndexOutOfBoundsException if the index is out of range
+	 *         ({@code index < 0 || index >= size()})
 	 */
-	public int get(int index) throws ArrayIndexOutOfBoundsException {
+	public int get(int index) {
 		if (index >= size) {
 			String message = "tried accessing element " + index + "/" + size;
 			throw new ArrayIndexOutOfBoundsException(message);
@@ -239,7 +242,7 @@ public class IntBag implements ImmutableIntBag {
 		data[index] = value;
 	}
 
-	private void grow(int newCapacity) throws ArrayIndexOutOfBoundsException {
+	private void grow(int newCapacity) {
 		int[] oldData = data;
 		data = new int[newCapacity];
 		System.arraycopy(oldData, 0, data, 0, oldData.length);

--- a/artemis-core/artemis/src/main/java/com/artemis/utils/IntDeque.java
+++ b/artemis-core/artemis/src/main/java/com/artemis/utils/IntDeque.java
@@ -55,9 +55,10 @@ public class IntDeque {
 	 *
 	 * @return the element at the specified position in bag
 	 *
-	 * @throws ArrayIndexOutOfBoundsException
+	 * @throws ArrayIndexOutOfBoundsException if the index is out of range
+	 *         ({@code index < 0 || index >= size()})
 	 */
-	public int get(int index) throws ArrayIndexOutOfBoundsException {
+	public int get(int index) {
 		return elements[index(index)];
 	}
 	
@@ -132,7 +133,7 @@ public class IntDeque {
 	 *
 	 * @throws ArrayIndexOutOfBoundsException if new capacity is smaller than old
 	 */
-	private void grow(int newCapacity) throws ArrayIndexOutOfBoundsException {
+	private void grow(int newCapacity) {
 		int[] newElements = new int[newCapacity];
 		for (int i = 0; i < size; i++)
 			newElements[i] = get(i);

--- a/artemis-core/artemis/src/main/java/com/artemis/utils/ShortBag.java
+++ b/artemis-core/artemis/src/main/java/com/artemis/utils/ShortBag.java
@@ -44,7 +44,7 @@ public class ShortBag {
 	 *
 	 * @return true, if value was removed
 	 */
-	public boolean removeValue(short value) throws ArrayIndexOutOfBoundsException {
+	public boolean removeValue(short value) {
 		int index = indexOf(value);
 		if (index > -1)
 			remove(index);
@@ -64,9 +64,10 @@ public class ShortBag {
 	 *
 	 * @return element that was removed from the Bag
 	 *
-	 * @throws ArrayIndexOutOfBoundsException
+	 * @throws ArrayIndexOutOfBoundsException if the index is out of range
+	 *         ({@code index < 0 || index >= size()})
 	 */
-	public int remove(int index) throws ArrayIndexOutOfBoundsException {
+	public int remove(int index) {
 		int e = data[index]; // make copy of element to remove so it can be returned
 		data[index] = data[--size]; // overwrite item to remove with last element
 		data[size] = 0; // null last element, so gc can do its work
@@ -115,9 +116,10 @@ public class ShortBag {
 	 *
 	 * @return the element at the specified position in bag
 	 *
-	 * @throws ArrayIndexOutOfBoundsException
+	 * @throws ArrayIndexOutOfBoundsException if the index is out of range
+	 *         ({@code index < 0 || index >= size()})
 	 */
-	public short get(int index) throws ArrayIndexOutOfBoundsException {
+	public short get(int index) {
 		return data[index];
 	}
 	
@@ -220,7 +222,7 @@ public class ShortBag {
 	 *
 	 * @throws ArrayIndexOutOfBoundsException if new capacity is smaller than old
 	 */
-	private void grow(int newCapacity) throws ArrayIndexOutOfBoundsException {
+	private void grow(int newCapacity) {
 		short[] oldData = data;
 		data = new short[newCapacity];
 		System.arraycopy(oldData, 0, data, 0, oldData.length);

--- a/artemis-core/artemis/src/main/java/com/artemis/utils/reflect/ClassReflection.java
+++ b/artemis-core/artemis/src/main/java/com/artemis/utils/reflect/ClassReflection.java
@@ -183,7 +183,7 @@ public final class ClassReflection {
 
 	/** Creates a new instance of the annotation represented by the supplied annotationClass.
 	 */
-	static public <T extends java.lang.annotation.Annotation> T getAnnotation(Class c, Class<T> annotationClass) throws ReflectionException {
+	static public <T extends java.lang.annotation.Annotation> T getAnnotation(Class c, Class<T> annotationClass) {
 		final Annotation declaredAnnotation = getDeclaredAnnotation(c,annotationClass);
 		return declaredAnnotation != null ? declaredAnnotation.getAnnotation(annotationClass) : null;
 	}

--- a/artemis-core/artemis/src/main/java/com/artemis/utils/reflect/SystemMetadata.java
+++ b/artemis-core/artemis/src/main/java/com/artemis/utils/reflect/SystemMetadata.java
@@ -24,23 +24,19 @@ public class SystemMetadata {
      * @return {@code Aspect.Builder} as defined in annotations, or {@code null} if none.
      */
     public Aspect.Builder getAspect() {
-        try {
-            final Aspect.Builder aspect = Aspect.all();
-            final All all = ClassReflection.getAnnotation(c, All.class);
-            if (all != null) {
-                aspect.all(all.value());
-            }
-            final One one = ClassReflection.getAnnotation(c, One.class);
-            if (one != null) {
-                aspect.one(one.value());
-            }
-            final Exclude exclude = ClassReflection.getAnnotation(c, Exclude.class);
-            if (exclude != null) {
-                aspect.exclude(exclude.value());
-            }
-            return (all != null || exclude != null || one != null) ? aspect : null;
-        } catch (ReflectionException e) {
-            throw new RuntimeException(e);
+        final Aspect.Builder aspect = Aspect.all();
+        final All all = ClassReflection.getAnnotation(c, All.class);
+        if (all != null) {
+            aspect.all(all.value());
         }
+        final One one = ClassReflection.getAnnotation(c, One.class);
+        if (one != null) {
+            aspect.one(one.value());
+        }
+        final Exclude exclude = ClassReflection.getAnnotation(c, Exclude.class);
+        if (exclude != null) {
+            aspect.exclude(exclude.value());
+        }
+        return (all != null || exclude != null || one != null) ? aspect : null;
     }
 }

--- a/artemis-core/artemis/src/test/java/com/artemis/ArchetypeManagerTest.java
+++ b/artemis-core/artemis/src/test/java/com/artemis/ArchetypeManagerTest.java
@@ -29,7 +29,7 @@ public class ArchetypeManagerTest {
 	}
 	
 	@Test
-	public void test_composition_id() throws Exception {
+	public void test_composition_id() {
 		assertEquals(0, arch1.transmuter.compositionId);
 		assertEquals(1, arch2.transmuter.compositionId);
 		assertEquals(2, arch3.transmuter.compositionId);

--- a/artemis-core/artemis/src/test/java/com/artemis/ArchetypeSystemTest.java
+++ b/artemis-core/artemis/src/test/java/com/artemis/ArchetypeSystemTest.java
@@ -29,7 +29,7 @@ public class ArchetypeSystemTest {
 	}
 	
 	@Test
-	public void test_composition_id() throws Exception {
+	public void test_composition_id() {
 		assertEquals(0, arch1.transmuter.compositionId);
 		assertEquals(1, arch2.transmuter.compositionId);
 		assertEquals(2, arch3.transmuter.compositionId);

--- a/artemis-core/artemis/src/test/java/com/artemis/ArchetypeTest.java
+++ b/artemis-core/artemis/src/test/java/com/artemis/ArchetypeTest.java
@@ -40,14 +40,14 @@ public class ArchetypeTest {
 	}
 
 	@Test
-	public void test_composition_id() throws Exception {
+	public void test_composition_id() {
 		assertEquals(0, arch1.transmuter.compositionId);
 		assertEquals(1, arch2.transmuter.compositionId);
 		assertEquals(2, arch3.transmuter.compositionId);
 	}
 
 	@Test
-	public void test_inherited_archetypes_and_composition_resolution() throws Exception {
+	public void test_inherited_archetypes_and_composition_resolution() {
 		Archetype arch4 = new ArchetypeBuilder(arch2).build(world);
 		Archetype arch5 = new ArchetypeBuilder(arch2).remove(ComponentY.class).build(world);
 		Archetype arch6 = new ArchetypeBuilder(arch2).remove(ComponentX.class).build(world);
@@ -96,7 +96,7 @@ public class ArchetypeTest {
 	}
 
 	@Test
-	public void testEntityCreationMod() throws Exception {
+	public void testEntityCreationMod() {
 		World world = new World();
 
 		ComponentMapper<ComponentX> xMapper = world.getMapper(ComponentX.class);

--- a/artemis-core/artemis/src/test/java/com/artemis/AspectFieldHandlerTest.java
+++ b/artemis-core/artemis/src/test/java/com/artemis/AspectFieldHandlerTest.java
@@ -18,7 +18,7 @@ public class AspectFieldHandlerTest {
 		.exclude(PooledString.class);
 
 	@Test
-	public void inject_aspect_fields_pojo() throws Exception {
+	public void inject_aspect_fields_pojo() {
 		WorldConfiguration worldConfiguration = new WorldConfiguration()
 			.setSystem(new SomeSystem())
 			.register(new Object());
@@ -43,7 +43,7 @@ public class AspectFieldHandlerTest {
 	}
 
 	@Test
-	public void inject_aspect_fields_system() throws Exception {
+	public void inject_aspect_fields_system() {
 		WorldConfiguration worldConfiguration = new WorldConfiguration()
 			.setSystem(new SomeSystem())
 			.register(new Object());

--- a/artemis-core/artemis/src/test/java/com/artemis/ComponentPoolTest.java
+++ b/artemis-core/artemis/src/test/java/com/artemis/ComponentPoolTest.java
@@ -11,8 +11,7 @@ public class ComponentPoolTest
 {
 	@SuppressWarnings("static-method")
 	@Test
-	public void reuse_pooled_components() throws Exception
-	{
+	public void reuse_pooled_components() {
 
 		ComponentType type = new ComponentType(SimplePooled.class, 0);
 		ComponentPool<SimplePooled> pool = new ComponentPool<SimplePooled>(SimplePooled.class);

--- a/artemis-core/artemis/src/test/java/com/artemis/DelayedComponentRemovalTest.java
+++ b/artemis-core/artemis/src/test/java/com/artemis/DelayedComponentRemovalTest.java
@@ -15,7 +15,7 @@ public class DelayedComponentRemovalTest {
     private WorldConfigurationBuilder builder;
 
     @Before
-    public void setUp() throws Exception {
+    public void setUp() {
         builder = new WorldConfigurationBuilder();
     }
 

--- a/artemis-core/artemis/src/test/java/com/artemis/DelayedEntityProcessingSystemTest.java
+++ b/artemis-core/artemis/src/test/java/com/artemis/DelayedEntityProcessingSystemTest.java
@@ -16,8 +16,7 @@ public class DelayedEntityProcessingSystemTest
 	private ExpirationSystem es;
 
 	@Before
-	public void setUp() throws Exception
-	{
+	public void setUp() {
 		world = new World(new WorldConfiguration()
 				.setSystem(new ExpirationSystem()));
 		world.inject(this);

--- a/artemis-core/artemis/src/test/java/com/artemis/DelayedIteratingSystemTest.java
+++ b/artemis-core/artemis/src/test/java/com/artemis/DelayedIteratingSystemTest.java
@@ -15,8 +15,7 @@ public class DelayedIteratingSystemTest
 	private ExpirationSystem es;
 
 	@Before
-	public void setUp() throws Exception
-	{
+	public void setUp() {
 		world = new World(new WorldConfiguration()
 				.setSystem(new ExpirationSystem()));
 		world.inject(this);

--- a/artemis-core/artemis/src/test/java/com/artemis/FieldHandlerTest.java
+++ b/artemis-core/artemis/src/test/java/com/artemis/FieldHandlerTest.java
@@ -16,7 +16,7 @@ import static org.junit.Assert.assertNull;
  */
 public class FieldHandlerTest {
     @Test
-    public void default_field_handler_injects_correct_core_fields() throws Exception {
+    public void default_field_handler_injects_correct_core_fields() {
         WorldConfiguration worldConfiguration = new WorldConfiguration()
                 .setSystem(new SomeSystem())
                 .setSystem(new SomeManager())
@@ -36,7 +36,7 @@ public class FieldHandlerTest {
 
 
     @Test
-    public void custom_field_resolver_injects_fields() throws Exception {
+    public void custom_field_resolver_injects_fields() {
         FieldHandler fieldHandler = new FieldHandler(new InjectionCache());
         fieldHandler.addFieldResolver(new AllFieldsResolver());
 
@@ -51,7 +51,7 @@ public class FieldHandlerTest {
     }
 
     @Test
-    public void default_field_handler_injects_world_fields() throws Exception {
+    public void default_field_handler_injects_world_fields() {
         WorldConfiguration worldConfiguration = new WorldConfiguration();
         World world = new World(worldConfiguration);
 

--- a/artemis-core/artemis/src/test/java/com/artemis/Issue357SystemTest.java
+++ b/artemis-core/artemis/src/test/java/com/artemis/Issue357SystemTest.java
@@ -10,7 +10,7 @@ import static org.junit.Assert.assertNotNull;
  */
 public class Issue357SystemTest {
 	@Test
-	public void test_two_systems_in_world_delete_during_process() throws Exception {
+	public void test_two_systems_in_world_delete_during_process() {
 		World world = new World(new WorldConfiguration().setSystem(TestSystemWithDelete.class)
 				.setSystem(AnyOldeBaseSystem.class));
 		world.createEntity().edit().create(TestComponent.class);
@@ -22,7 +22,7 @@ public class Issue357SystemTest {
 	}
 
 	@Test
-	public void test_one_system_in_world_delete_during_process() throws Exception {
+	public void test_one_system_in_world_delete_during_process() {
 		World world = new World(new WorldConfiguration().setSystem(TestSystemWithDelete.class));
 		world.createEntity().edit().create(TestComponent.class);
 		world.process();
@@ -33,7 +33,7 @@ public class Issue357SystemTest {
 	}
 
 	@Test
-	public void test_two_systems_in_world_delete_after_process() throws Exception {
+	public void test_two_systems_in_world_delete_after_process() {
 		World world = new World(new WorldConfiguration().setSystem(TestSystemWithoutDelete.class)
 				.setSystem(AnyOldeBaseSystem.class));
 		Entity entity = world.createEntity();
@@ -50,7 +50,7 @@ public class Issue357SystemTest {
 	}
 
 	@Test
-	public void test_two_systems_in_world_delete_before_process() throws Exception {
+	public void test_two_systems_in_world_delete_before_process() {
 		World world = new World(new WorldConfiguration()
 			.setSystem(TestSystemWithoutDelete.class)
 			.setSystem(AnyOldeBaseSystem.class));

--- a/artemis-core/artemis/src/test/java/com/artemis/WorldConfigurationBuilderInjectionTest.java
+++ b/artemis-core/artemis/src/test/java/com/artemis/WorldConfigurationBuilderInjectionTest.java
@@ -17,7 +17,7 @@ public class WorldConfigurationBuilderInjectionTest {
 	private WorldConfigurationBuilder builder;
 
 	@Before
-	public void setUp() throws Exception {
+	public void setUp() {
 		builder = new WorldConfigurationBuilder();
 	}
 

--- a/artemis-core/artemis/src/test/java/com/artemis/WorldConfigurationBuilderManagerTest.java
+++ b/artemis-core/artemis/src/test/java/com/artemis/WorldConfigurationBuilderManagerTest.java
@@ -15,7 +15,7 @@ public class WorldConfigurationBuilderManagerTest {
 	private WorldConfigurationBuilder builder;
 
 	@Before
-	public void setUp() throws Exception {
+	public void setUp() {
 		builder = new WorldConfigurationBuilder();
 	}
 

--- a/artemis-core/artemis/src/test/java/com/artemis/WorldConfigurationBuilderPluginTest.java
+++ b/artemis-core/artemis/src/test/java/com/artemis/WorldConfigurationBuilderPluginTest.java
@@ -20,7 +20,7 @@ public class WorldConfigurationBuilderPluginTest {
     private ArtemisPlugin plugin;
 
     @Before
-    public void setUp() throws Exception {
+    public void setUp() {
         builder = new WorldConfigurationBuilder();
         plugin = mock(ArtemisPlugin.class);
     }

--- a/artemis-core/artemis/src/test/java/com/artemis/WorldConfigurationBuilderSystemTest.java
+++ b/artemis-core/artemis/src/test/java/com/artemis/WorldConfigurationBuilderSystemTest.java
@@ -16,7 +16,7 @@ public class WorldConfigurationBuilderSystemTest {
 	private WorldConfigurationBuilder builder;
 
 	@Before
-	public void setUp() throws Exception {
+	public void setUp() {
 		builder = new WorldConfigurationBuilder();
 	}
 

--- a/artemis-core/artemis/src/test/java/com/artemis/managers/GroupManagerTest.java
+++ b/artemis-core/artemis/src/test/java/com/artemis/managers/GroupManagerTest.java
@@ -18,7 +18,7 @@ public class GroupManagerTest {
 	private GroupManager gm;
 
 	@Before
-	public void setUp() throws Exception {
+	public void setUp() {
 		gm = new GroupManager();
 		world = new World(new WorldConfiguration()
 				.setSystem(gm));

--- a/artemis-core/artemis/src/test/java/com/artemis/managers/TagManagerTest.java
+++ b/artemis-core/artemis/src/test/java/com/artemis/managers/TagManagerTest.java
@@ -9,7 +9,7 @@ import static org.junit.Assert.*;
 public class TagManagerTest {
 
 	@Test
-	public void test_overwriting_tag() throws Exception {
+	public void test_overwriting_tag() {
 		World w = new World(new WorldConfiguration()
 			.setSystem(TagManager.class));
 

--- a/artemis-fluid/artemis-fluid-maven-integration-test/artemis-fluid-maven-integration-test-systems/src/test/java/com/artemis/annotation/FluidIntegrationTest.java
+++ b/artemis-fluid/artemis-fluid-maven-integration-test/artemis-fluid-maven-integration-test-systems/src/test/java/com/artemis/annotation/FluidIntegrationTest.java
@@ -14,7 +14,7 @@ import static com.artemis.E.E;
 public class FluidIntegrationTest extends AbstractStrategyIntegrationTest {
 
     @Test
-    public void When_excluding_component_Should_exclude_component() throws Exception {
+    public void When_excluding_component_Should_exclude_component() {
 
         class TestSystem extends BaseSystem {
             @Override
@@ -33,7 +33,7 @@ public class FluidIntegrationTest extends AbstractStrategyIntegrationTest {
     }
 
     @Test
-    public void When_specified_name_Should_apply_name_on_component() throws Exception {
+    public void When_specified_name_Should_apply_name_on_component() {
 
         class TestSystem extends BaseSystem {
             @Override
@@ -51,7 +51,7 @@ public class FluidIntegrationTest extends AbstractStrategyIntegrationTest {
     }
 
     @Test
-    public void When_swallowing_parameterized_getters_Should_return_fluid_instead_of_parameterized_getter_return_value() throws Exception {
+    public void When_swallowing_parameterized_getters_Should_return_fluid_instead_of_parameterized_getter_return_value() {
 
         class TestSystem extends BaseSystem {
             @Override

--- a/artemis-fluid/artemis-fluid-maven-integration-test/artemis-fluid-maven-integration-test-systems/src/test/java/com/artemis/fieldstrategies/FieldProxyStrategyTest.java
+++ b/artemis-fluid/artemis-fluid-maven-integration-test/artemis-fluid-maven-integration-test-systems/src/test/java/com/artemis/fieldstrategies/FieldProxyStrategyTest.java
@@ -11,7 +11,7 @@ import org.junit.Test;
  */
 public class FieldProxyStrategyTest extends AbstractStrategyIntegrationTest {
     @Test
-    public void When_two_proxy_strategies_match_same_class_Should_follow_priority() throws Exception {
+    public void When_two_proxy_strategies_match_same_class_Should_follow_priority() {
 
         class TestSystem extends BaseSystem {
             @Override

--- a/artemis-fluid/artemis-fluid-maven-integration-test/artemis-fluid-maven-integration-test-systems/src/test/java/com/artemis/generator/strategy/e/CodeCoverageHack.java
+++ b/artemis-fluid/artemis-fluid-maven-integration-test/artemis-fluid-maven-integration-test-systems/src/test/java/com/artemis/generator/strategy/e/CodeCoverageHack.java
@@ -14,7 +14,7 @@ public class CodeCoverageHack extends AbstractStrategyIntegrationTest {
 
 
     @Test
-    public void When_fluid_toggle_flag_component_Should_affect_component_and_return_fluid() throws Exception {
+    public void When_fluid_toggle_flag_component_Should_affect_component_and_return_fluid() {
 
         class TestSystem extends BaseSystem {
             @Override

--- a/artemis-fluid/artemis-fluid-maven-integration-test/artemis-fluid-maven-integration-test-systems/src/test/java/com/artemis/generator/strategy/e/ComponentAllStrategyIntegrationTest.java
+++ b/artemis-fluid/artemis-fluid-maven-integration-test/artemis-fluid-maven-integration-test-systems/src/test/java/com/artemis/generator/strategy/e/ComponentAllStrategyIntegrationTest.java
@@ -17,7 +17,7 @@ public class ComponentAllStrategyIntegrationTest extends AbstractStrategyIntegra
 
 
     @Test
-    public void When_fluid_create_component_Should_create_component_and_return_fluid() throws Exception {
+    public void When_fluid_create_component_Should_create_component_and_return_fluid() {
 
         class TestSystem extends BaseSystem {
             @Override
@@ -30,7 +30,7 @@ public class ComponentAllStrategyIntegrationTest extends AbstractStrategyIntegra
     }
 
     @Test
-    public void When_fluid_remove_component_Should_remove_component_and_return_fluid() throws Exception {
+    public void When_fluid_remove_component_Should_remove_component_and_return_fluid() {
 
         class TestSystem extends BaseSystem {
             @Override
@@ -43,7 +43,7 @@ public class ComponentAllStrategyIntegrationTest extends AbstractStrategyIntegra
     }
 
     @Test
-    public void When_fluid_fetch_component_Should_return_component() throws Exception {
+    public void When_fluid_fetch_component_Should_return_component() {
 
         class TestSystem extends BaseSystem {
             @Override

--- a/artemis-fluid/artemis-fluid-maven-integration-test/artemis-fluid-maven-integration-test-systems/src/test/java/com/artemis/generator/strategy/e/ComponentFieldAccessorStrategyIntegrationTest.java
+++ b/artemis-fluid/artemis-fluid-maven-integration-test/artemis-fluid-maven-integration-test-systems/src/test/java/com/artemis/generator/strategy/e/ComponentFieldAccessorStrategyIntegrationTest.java
@@ -15,7 +15,7 @@ public class ComponentFieldAccessorStrategyIntegrationTest extends AbstractStrat
 
 
     @Test
-    public void When_fluid_setget_component_field_Should_setget_component_field_value() throws Exception {
+    public void When_fluid_setget_component_field_Should_setget_component_field_value() {
 
         class TestSystem extends BaseSystem {
             @Override
@@ -31,7 +31,7 @@ public class ComponentFieldAccessorStrategyIntegrationTest extends AbstractStrat
     }
 
     @Test
-    public void When_fluid_set_method_Should_fluid_expose_method() throws Exception {
+    public void When_fluid_set_method_Should_fluid_expose_method() {
 
         class TestSystem extends BaseSystem {
             @Override
@@ -46,7 +46,7 @@ public class ComponentFieldAccessorStrategyIntegrationTest extends AbstractStrat
     }
 
     @Test
-    public void When_fluid_custom_getter_Should_expose_without_fluid_return_value() throws Exception {
+    public void When_fluid_custom_getter_Should_expose_without_fluid_return_value() {
 
         class TestSystem extends BaseSystem {
             @Override
@@ -59,7 +59,7 @@ public class ComponentFieldAccessorStrategyIntegrationTest extends AbstractStrat
     }
 
     @Test
-    public void When_fluid_parameterized_getter_Should_expose_without_fluid_return_value_by_default() throws Exception {
+    public void When_fluid_parameterized_getter_Should_expose_without_fluid_return_value_by_default() {
 
         class TestSystem extends BaseSystem {
             @Override

--- a/artemis-fluid/artemis-fluid-maven-integration-test/artemis-fluid-maven-integration-test-systems/src/test/java/com/artemis/generator/strategy/e/ComponentGroupStrategyIntegrationTest.java
+++ b/artemis-fluid/artemis-fluid-maven-integration-test/artemis-fluid-maven-integration-test-systems/src/test/java/com/artemis/generator/strategy/e/ComponentGroupStrategyIntegrationTest.java
@@ -13,7 +13,7 @@ import org.junit.Test;
 public class ComponentGroupStrategyIntegrationTest extends AbstractStrategyIntegrationTest {
 
     @Test
-    public void When_fluid_set_group_Should_set_group() throws Exception {
+    public void When_fluid_set_group_Should_set_group() {
 
         class TestSystem extends BaseSystem {
             public GroupManager groupManager;
@@ -28,7 +28,7 @@ public class ComponentGroupStrategyIntegrationTest extends AbstractStrategyInteg
     }
 
     @Test
-    public void When_fluid_set_groups_Should_set_groups() throws Exception {
+    public void When_fluid_set_groups_Should_set_groups() {
 
         class TestSystem extends BaseSystem {
             public GroupManager groupManager;
@@ -44,7 +44,7 @@ public class ComponentGroupStrategyIntegrationTest extends AbstractStrategyInteg
     }
 
     @Test
-    public void When_fluid_remove_group_Should_remove_group() throws Exception {
+    public void When_fluid_remove_group_Should_remove_group() {
 
         class TestSystem extends BaseSystem {
             public GroupManager groupManager;
@@ -62,7 +62,7 @@ public class ComponentGroupStrategyIntegrationTest extends AbstractStrategyInteg
 
 
     @Test
-    public void When_fluid_remove_groups_Should_remove_groups() throws Exception {
+    public void When_fluid_remove_groups_Should_remove_groups() {
 
         class TestSystem extends BaseSystem {
             public GroupManager groupManager;
@@ -80,7 +80,7 @@ public class ComponentGroupStrategyIntegrationTest extends AbstractStrategyInteg
 
 
     @Test
-    public void When_fluid_remove_all_groups_Should_remove_all_groups() throws Exception {
+    public void When_fluid_remove_all_groups_Should_remove_all_groups() {
 
         class TestSystem extends BaseSystem {
             public GroupManager groupManager;
@@ -98,7 +98,7 @@ public class ComponentGroupStrategyIntegrationTest extends AbstractStrategyInteg
 
 
     @Test
-    public void When_fluid_check_in_group_Should_report_group_membership() throws Exception {
+    public void When_fluid_check_in_group_Should_report_group_membership() {
 
         class TestSystem extends BaseSystem {
             public GroupManager groupManager;
@@ -114,7 +114,7 @@ public class ComponentGroupStrategyIntegrationTest extends AbstractStrategyInteg
 
 
     @Test
-    public void When_fluid_check_groups_Should_return_groups() throws Exception {
+    public void When_fluid_check_groups_Should_return_groups() {
 
         class TestSystem extends BaseSystem {
             public GroupManager groupManager;
@@ -132,7 +132,7 @@ public class ComponentGroupStrategyIntegrationTest extends AbstractStrategyInteg
 
 
     @Test
-    public void When_fetching_entities_in_group_Should_properly_resolve_group_members() throws Exception {
+    public void When_fetching_entities_in_group_Should_properly_resolve_group_members() {
         class TestSystem extends BaseSystem {
             public GroupManager groupManager;
             @Override
@@ -151,7 +151,7 @@ public class ComponentGroupStrategyIntegrationTest extends AbstractStrategyInteg
 
 
     @Test
-    public void When_fetching_entities_in_empty_group_Should_return_empty_group() throws Exception {
+    public void When_fetching_entities_in_empty_group_Should_return_empty_group() {
         class TestSystem extends BaseSystem {
             public GroupManager groupManager;
             @Override

--- a/artemis-fluid/artemis-fluid-maven-integration-test/artemis-fluid-maven-integration-test-systems/src/test/java/com/artemis/generator/strategy/e/ComponentTagStrategyIntegrationTest.java
+++ b/artemis-fluid/artemis-fluid-maven-integration-test/artemis-fluid-maven-integration-test-systems/src/test/java/com/artemis/generator/strategy/e/ComponentTagStrategyIntegrationTest.java
@@ -14,7 +14,7 @@ import org.junit.Test;
 public class ComponentTagStrategyIntegrationTest extends AbstractStrategyIntegrationTest {
 
     @Test
-    public void When_fluid_set_tag_Should_set_tag() throws Exception {
+    public void When_fluid_set_tag_Should_set_tag() {
 
         class TestSystem extends BaseSystem {
             public TagManager tagManager;
@@ -30,7 +30,7 @@ public class ComponentTagStrategyIntegrationTest extends AbstractStrategyIntegra
 
 
     @Test
-    public void When_fluid_get_tag_Should_get_tag() throws Exception {
+    public void When_fluid_get_tag_Should_get_tag() {
 
         class TestSystem extends BaseSystem {
             @Override
@@ -43,7 +43,7 @@ public class ComponentTagStrategyIntegrationTest extends AbstractStrategyIntegra
     }
 
     @Test
-    public void When_find_entity_by_tag_Should_get_entity_by_tag() throws Exception {
+    public void When_find_entity_by_tag_Should_get_entity_by_tag() {
         class TestSystem extends BaseSystem {
             @Override
             protected void processSystem() {
@@ -57,7 +57,7 @@ public class ComponentTagStrategyIntegrationTest extends AbstractStrategyIntegra
 
 
     @Test
-    public void When_find_entity_by_invalid_tag_Should_get_null() throws Exception {
+    public void When_find_entity_by_invalid_tag_Should_get_null() {
         class TestSystem extends BaseSystem {
             @Override
             protected void processSystem() {

--- a/artemis-fluid/artemis-fluid-maven-integration-test/artemis-fluid-maven-integration-test-systems/src/test/java/com/artemis/generator/strategy/e/DeleteFromWorldIntegrationTest.java
+++ b/artemis-fluid/artemis-fluid-maven-integration-test/artemis-fluid-maven-integration-test-systems/src/test/java/com/artemis/generator/strategy/e/DeleteFromWorldIntegrationTest.java
@@ -13,7 +13,7 @@ public class DeleteFromWorldIntegrationTest extends AbstractStrategyIntegrationT
 
 
     @Test
-    public void When_fluid_deleteFromWorld_Should_delete_from_world() throws Exception {
+    public void When_fluid_deleteFromWorld_Should_delete_from_world() {
 
         class TestSystem extends BaseSystem {
             public int entityId;

--- a/artemis-fluid/artemis-fluid-maven-integration-test/artemis-fluid-maven-integration-test-systems/src/test/java/com/artemis/generator/strategy/e/EQueryExtensionsStrategyIntegrationTest.java
+++ b/artemis-fluid/artemis-fluid-maven-integration-test/artemis-fluid-maven-integration-test-systems/src/test/java/com/artemis/generator/strategy/e/EQueryExtensionsStrategyIntegrationTest.java
@@ -17,7 +17,7 @@ public class EQueryExtensionsStrategyIntegrationTest extends AbstractStrategyInt
     private static final Aspect.Builder BASIC_FLAG_ASPECT = Aspect.all(Basic.class, Flag.class);
 
     @Test
-    public void When_fetching_entities_by_aspect_Should_return_matching_entities() throws Exception {
+    public void When_fetching_entities_by_aspect_Should_return_matching_entities() {
         class TestSystem extends BaseSystem {
             @Override
             protected void processSystem() {
@@ -32,7 +32,7 @@ public class EQueryExtensionsStrategyIntegrationTest extends AbstractStrategyInt
     }
 
     @Test
-    public void When_fetching_entities_by_component_Should_return_matching_entities() throws Exception {
+    public void When_fetching_entities_by_component_Should_return_matching_entities() {
         class TestSystem extends BaseSystem {
             @Override
             protected void processSystem() {
@@ -47,7 +47,7 @@ public class EQueryExtensionsStrategyIntegrationTest extends AbstractStrategyInt
 
     }
     @Test
-    public void When_no_entities_with_aspect_Should_return_empty_ebag() throws Exception {
+    public void When_no_entities_with_aspect_Should_return_empty_ebag() {
         class TestSystem extends BaseSystem {
             @Override
             protected void processSystem() {
@@ -59,7 +59,7 @@ public class EQueryExtensionsStrategyIntegrationTest extends AbstractStrategyInt
     }
 
     @Test
-    public void When_no_entities_with_component_Should_return_empty_bag() throws Exception {
+    public void When_no_entities_with_component_Should_return_empty_bag() {
         class TestSystem extends BaseSystem {
             @Override
             protected void processSystem() {

--- a/artemis-fluid/artemis-fluid-maven-integration-test/artemis-fluid-maven-integration-test-systems/src/test/java/com/artemis/generator/strategy/e/ESubscriptionIntegrationTest.java
+++ b/artemis-fluid/artemis-fluid-maven-integration-test/artemis-fluid-maven-integration-test-systems/src/test/java/com/artemis/generator/strategy/e/ESubscriptionIntegrationTest.java
@@ -15,7 +15,7 @@ import org.junit.Test;
 public class ESubscriptionIntegrationTest extends AbstractStrategyIntegrationTest {
 
     @Test
-    public void When_ESubscription_And_Aspect_Annotations_Should_inject() throws Exception {
+    public void When_ESubscription_And_Aspect_Annotations_Should_inject() {
         class TestSystem extends BaseSystem {
 
             @All(Basic.class)

--- a/artemis-fluid/artemis-fluid-maven-integration-test/artemis-fluid-maven-integration-test-systems/src/test/java/com/artemis/generator/strategy/e/FlagComponentBooleanAccessorStrategyIntegrationTest.java
+++ b/artemis-fluid/artemis-fluid-maven-integration-test/artemis-fluid-maven-integration-test-systems/src/test/java/com/artemis/generator/strategy/e/FlagComponentBooleanAccessorStrategyIntegrationTest.java
@@ -15,7 +15,7 @@ public class FlagComponentBooleanAccessorStrategyIntegrationTest extends Abstrac
 
 
     @Test
-    public void When_fluid_toggle_flag_component_Should_affect_component_and_return_fluid() throws Exception {
+    public void When_fluid_toggle_flag_component_Should_affect_component_and_return_fluid() {
 
         class TestSystem extends BaseSystem {
             @Override

--- a/artemis-fluid/artemis-fluid-maven-plugin/src/main/java/com/artemis/ArtemisFluidMaven.java
+++ b/artemis-fluid/artemis-fluid-maven-plugin/src/main/java/com/artemis/ArtemisFluidMaven.java
@@ -51,7 +51,7 @@ public class ArtemisFluidMaven extends AbstractMojo {
     private MavenFluidGeneratorPreferences preferences = new MavenFluidGeneratorPreferences();
 
     @Override
-    public void execute() throws MojoExecutionException, MojoFailureException {
+    public void execute() {
 
         prepareGeneratedSourcesFolder();
         includeGeneratedSourcesInCompilation();

--- a/artemis-serialization/artemis-json-libgdx/src/main/java/com/artemis/io/JsonArtemisSerializer.java
+++ b/artemis-serialization/artemis-json-libgdx/src/main/java/com/artemis/io/JsonArtemisSerializer.java
@@ -63,7 +63,7 @@ public class JsonArtemisSerializer extends WorldSerializationManager.ArtemisSeri
 		return this;
 	}
 
-	public void save(Writer writer, SaveFileFormat save) {
+	private void save(Writer writer, SaveFileFormat save) {
 		try {
 			referenceTracker.inspectTypes(world);
 			referenceTracker.preWrite(save);
@@ -88,7 +88,7 @@ public class JsonArtemisSerializer extends WorldSerializationManager.ArtemisSeri
 	}
 
 	@Override
-	protected void save(OutputStream out, SaveFileFormat save) throws SerializationException {
+	protected void save(OutputStream out, SaveFileFormat save) {
 		save(new OutputStreamWriter(out), save);
 	}
 

--- a/artemis-serialization/artemis-json-libgdx/src/test/java/com/artemis/managers/EntityReferencesTest.java
+++ b/artemis-serialization/artemis-json-libgdx/src/test/java/com/artemis/managers/EntityReferencesTest.java
@@ -25,7 +25,7 @@ public class EntityReferencesTest {
 	private ComponentMapper<LevelState> levelStateMapper;
 
 	@Test
-	public void load_before_save() throws Exception {
+	public void load_before_save() {
 		SaveFileFormat load = loadWorld();
 
 		Entity base = tags.getEntity("level");
@@ -43,7 +43,7 @@ public class EntityReferencesTest {
 	}
 
 		@Test
-	public void load_entity_with_references() throws Exception {
+	public void load_entity_with_references() {
 		SaveFileFormat load = loadWorld();
 
 		Entity base = tags.getEntity("level");

--- a/artemis-serialization/artemis-json-libgdx/src/test/java/com/artemis/prefab/PrefabTest.java
+++ b/artemis-serialization/artemis-json-libgdx/src/test/java/com/artemis/prefab/PrefabTest.java
@@ -42,7 +42,7 @@ public class PrefabTest {
 	}
 
 	@Test
-	public void load_prefab() throws Exception {
+	public void load_prefab() {
 		SomePrefab prefab = new SomePrefab(world, new ClasspathFileHandleResolver());
 		String text = "updating whatever's ComponentX";
 		SaveFileFormat l = prefab.create(text);

--- a/artemis-serialization/artemis-json/src/main/java/com/artemis/io/JsonArtemisSerializer.java
+++ b/artemis-serialization/artemis-json/src/main/java/com/artemis/io/JsonArtemisSerializer.java
@@ -85,7 +85,7 @@ public class JsonArtemisSerializer extends WorldSerializationManager.ArtemisSeri
 	}
 
 	@Override
-	protected void save(OutputStream out, SaveFileFormat save) throws SerializationException {
+	protected void save(OutputStream out, SaveFileFormat save) {
 		save(new OutputStreamWriter(out), save);
 	}
 

--- a/artemis-serialization/artemis-json/src/test/java/com/artemis/managers/EntityReferencesTest.java
+++ b/artemis-serialization/artemis-json/src/test/java/com/artemis/managers/EntityReferencesTest.java
@@ -25,7 +25,7 @@ public class EntityReferencesTest {
 	private ComponentMapper<LevelState> levelStateMapper;
 
 	@Test
-	public void load_before_save() throws Exception {
+	public void load_before_save() {
 		SaveFileFormat load = loadWorld();
 
 		Entity base = tags.getEntity("level");
@@ -43,7 +43,7 @@ public class EntityReferencesTest {
 	}
 
 		@Test
-	public void load_entity_with_references() throws Exception {
+	public void load_entity_with_references() {
 		SaveFileFormat load = loadWorld();
 
 		Entity base = tags.getEntity("level");

--- a/artemis-serialization/artemis-json/src/test/java/com/artemis/prefab/PrefabTest.java
+++ b/artemis-serialization/artemis-json/src/test/java/com/artemis/prefab/PrefabTest.java
@@ -33,7 +33,7 @@ public class PrefabTest {
 	}
 
 	@Test
-	public void load_prefab() throws Exception {
+	public void load_prefab() {
 		SomePrefab prefab = new SomePrefab(world, new JsonValuePrefabReader());
 		String text = "updating whatever's ComponentX";
 		SaveFileFormat l = prefab.create(text);

--- a/artemis-serialization/artemis-kryo/src/main/java/com/artemis/io/KryoArtemisSerializer.java
+++ b/artemis-serialization/artemis-kryo/src/main/java/com/artemis/io/KryoArtemisSerializer.java
@@ -78,8 +78,7 @@ public class KryoArtemisSerializer extends WorldSerializationManager.ArtemisSeri
 	}
 
 	@Override
-	public void save(OutputStream os, SaveFileFormat save)
-			throws SerializationException {
+	public void save(OutputStream os, SaveFileFormat save) {
 
 		referenceTracker.inspectTypes(world);
 		referenceTracker.preWrite(save);

--- a/artemis-serialization/artemis-kryo/src/test/java/com/artemis/managers/CustomKryoWorldSerializationManagerTest.java
+++ b/artemis-serialization/artemis-kryo/src/test/java/com/artemis/managers/CustomKryoWorldSerializationManagerTest.java
@@ -48,7 +48,7 @@ public class CustomKryoWorldSerializationManagerTest {
 	}
 
 	@Test
-	public void custom_save_format_save_load() throws Exception {
+	public void custom_save_format_save_load() {
 		serializedSystem.serializeMe = "dog";
 
 		byte[] save = save(allEntities, "a string", 420);
@@ -67,9 +67,7 @@ public class CustomKryoWorldSerializationManagerTest {
 		assertEquals(420, load.noSerializer.number);
 	}
 
-	private byte[] save(EntitySubscription subscription, String s, int i)
-			throws Exception {
-
+	private byte[] save(EntitySubscription subscription, String s, int i) {
 		SaveFileFormat save = new CustomSaveFormat(subscription, s, i);
 		ByteArrayOutputStream baos = new ByteArrayOutputStream(256);
 		manger.save(baos, save);

--- a/artemis-serialization/artemis-kryo/src/test/java/com/artemis/managers/KryoEntityReferencesTest.java
+++ b/artemis-serialization/artemis-kryo/src/test/java/com/artemis/managers/KryoEntityReferencesTest.java
@@ -24,7 +24,7 @@ public class KryoEntityReferencesTest {
 	private ComponentMapper<LevelState> levelStateMapper;
 
 	@Test
-	public void load_before_save() throws Exception {
+	public void load_before_save() {
 		SaveFileFormat load = loadWorld();
 
 		Entity base = tags.getEntity("level");
@@ -42,7 +42,7 @@ public class KryoEntityReferencesTest {
 	}
 
 		@Test
-	public void load_entity_with_references() throws Exception {
+	public void load_entity_with_references() {
 		SaveFileFormat load = loadWorld();
 
 		Entity base = tags.getEntity("level");

--- a/artemis-serialization/artemis-kryo/src/test/java/com/artemis/managers/KryoWorldSerializationManagerTest.java
+++ b/artemis-serialization/artemis-kryo/src/test/java/com/artemis/managers/KryoWorldSerializationManagerTest.java
@@ -556,7 +556,7 @@ public class KryoWorldSerializationManagerTest {
 		return save(subscription.getEntities());
 	}
 
-	private byte[] save(IntBag entities) throws Exception {
+	private byte[] save(IntBag entities) {
 		SaveFileFormat save = new SaveFileFormat(entities);
 		ByteArrayOutputStream baos = new ByteArrayOutputStream(256);
 		manger.save(baos, save);

--- a/artemis-serialization/artemis-serializer/src/main/java/com/artemis/io/ArchetypeMapper.java
+++ b/artemis-serialization/artemis-serializer/src/main/java/com/artemis/io/ArchetypeMapper.java
@@ -61,15 +61,11 @@ public class ArchetypeMapper {
 		private transient EntityTransmuter transmuter;
 
 		public TransmuterEntry(Bag<Class<? extends Component>> types) {
-			try {
-				for (Class<? extends Component> c : types) {
-					if (ClassReflection.getAnnotation(c, Transient.class) != null)
-						continue;
+			for (Class<? extends Component> c : types) {
+				if (ClassReflection.getAnnotation(c, Transient.class) != null)
+					continue;
 
-					componentTypes.add(c);
-				}
-			} catch (ReflectionException e) {
-				throw new RuntimeException(e);
+				componentTypes.add(c);
 			}
 		}
 

--- a/artemis-serialization/artemis-serializer/src/main/java/com/artemis/managers/WorldSerializationManager.java
+++ b/artemis-serialization/artemis-serializer/src/main/java/com/artemis/managers/WorldSerializationManager.java
@@ -55,9 +55,12 @@ public class WorldSerializationManager extends BaseSystem {
 		return backend.load(is, format);
 	}
 
-	public void save(OutputStream out, SaveFileFormat format) throws SerializationException {
+	/**
+	 * @throws SerializationException if {@link ArtemisSerializer} was not set
+	 */
+	public void save(OutputStream out, SaveFileFormat format) {
 		if (backend == null) {
-			throw new RuntimeException("Missing ArtemisSerializer, see #setBackend.");
+			throw new SerializationException("Missing ArtemisSerializer, see #setSerializer.");
 		}
 
 		world.inject(format);
@@ -107,8 +110,7 @@ public class WorldSerializationManager extends BaseSystem {
 		 */
 		public abstract ArtemisSerializer register(Class<?> type, T serializer);
 
-		protected abstract void save(OutputStream out, SaveFileFormat format)
-			throws SerializationException;
+		protected abstract void save(OutputStream out, SaveFileFormat format);
 		
 		/**
 		 * Deserializes data (usually a file) of a known class to a SaveFileFormat.

--- a/artemis-serialization/artemis-serializer/src/main/java/com/artemis/prefab/BasePrefab.java
+++ b/artemis-serialization/artemis-serializer/src/main/java/com/artemis/prefab/BasePrefab.java
@@ -36,18 +36,13 @@ public abstract class BasePrefab<DATA, SERIALIZER extends ArtemisSerializer> {
 	}
 
 	private String getPrefabDataPath() {
-		try {
-			PrefabData pd = ClassReflection.getAnnotation(getClass(), PrefabData.class);
-			if (pd != null) {
-				return pd.value();
-			} else {
-
-				String annotation = PrefabData.class.getSimpleName();
-				String message = getClass().getName() + " must be annotated with @" + annotation;
-				throw new MissingPrefabDataException(message);
-			}
-		} catch (ReflectionException e) {
-			throw new MissingPrefabDataException(e);
+		PrefabData pd = ClassReflection.getAnnotation(getClass(), PrefabData.class);
+		if (pd != null) {
+			return pd.value();
+		} else {
+			String annotation = PrefabData.class.getSimpleName();
+			String message = getClass().getName() + " must be annotated with @" + annotation;
+			throw new MissingPrefabDataException(message);
 		}
 	}
 


### PR DESCRIPTION
### Substitute unchecked exceptions API with javadoc @throws
Declaration of unchecked exceptions with `throws` keyword is misleading. It creates an illusion that an exception is a checked one and must be handled by the caller in order to recover. It is better to use `@throws` javadoc tag with description of what unchecked exceptions the method can throw (Effective Java, 3rd, Item 74).

Therefore I suggest to remove and substitute with javadoc all unchecked exceptions (including ArrayIndexOutOfBoundsException and SerializationException).

### Remove redundant throw clauses
Many methods (including ones from unit test classes and ClassReflection#getAnnotation) have redundant `throws Exception` declarations which are noisy and do not bring any relevant info. I suggest to remove them too.