### PR TITLE
add support for generic component classes

### DIFF
--- a/artemis-fluid/artemis-fluid-core/src/main/java/com/artemis/generator/strategy/e/DefaultFieldProxyStrategy.java
+++ b/artemis-fluid/artemis-fluid-core/src/main/java/com/artemis/generator/strategy/e/DefaultFieldProxyStrategy.java
@@ -1,5 +1,6 @@
 package com.artemis.generator.strategy.e;
 
+import static com.artemis.generator.util.ExtendedTypeReflection.resolveGenericType;
 import com.artemis.generator.model.FluidTypes;
 import com.artemis.generator.model.artemis.ComponentDescriptor;
 import com.artemis.generator.model.type.MethodDescriptor;
@@ -46,7 +47,7 @@ public class DefaultFieldProxyStrategy implements FieldProxyStrategy {
      * int E::posX() -> obtain field directly via interface.
      */
     private MethodDescriptor fieldGetterMethod(ComponentDescriptor component, Field field) {
-        return new MethodBuilder(field.getGenericType(), component.getCompositeName(field.getName()))
+        return new MethodBuilder(resolveGenericType(component, field), component.getCompositeName(field.getName()))
                 .mapper("return ", component, ".create(entityId)." + field.getName())
                 .debugNotes(field.toGenericString())
                 .build();
@@ -58,7 +59,7 @@ public class DefaultFieldProxyStrategy implements FieldProxyStrategy {
     private MethodDescriptor fieldSetterMethod(ComponentDescriptor component, Field field) {
         final String parameterName = field.getName();
         return new MethodBuilder(FluidTypes.E_TYPE, component.getCompositeName(parameterName))
-                .parameter(field.getGenericType(), parameterName)
+                .parameter(resolveGenericType(component, field), parameterName)
                 .mapper(component, ".create(this.entityId)." + parameterName + "=" + parameterName)
                 .debugNotes(field.toGenericString())
                 .returnFluid()

--- a/artemis-fluid/artemis-fluid-core/src/test/java/com/artemis/generator/strategy/e/ComponentFieldAccessorStrategyTest.java
+++ b/artemis-fluid/artemis-fluid-core/src/test/java/com/artemis/generator/strategy/e/ComponentFieldAccessorStrategyTest.java
@@ -63,4 +63,20 @@ public class ComponentFieldAccessorStrategyTest extends StrategyTest {
         TypeModel model = applyStrategy(ComponentFieldAccessorStrategy.class, Proof.class);
         assertHasMethod(model, "com.artemis.E proofGen(java.util.List<java.lang.Object> gen)");
     }
+
+    @Test
+    public void When_public_field_is_defined_in_generic_base_class() {
+        TypeModel model = applyStrategy(ComponentFieldAccessorStrategy.class, StringComponent.class);
+        assertHasMethod(model, "com.artemis.E stringComponentValue(java.lang.String value)");
+        assertHasMethod(model, "java.lang.String stringComponentValue()");
+    }
+
+    @Test
+    public void When_public_field_is_defined_in_generic_base_class_with_intermediate_class() {
+        TypeModel model = applyStrategy(ComponentFieldAccessorStrategy.class, SimpleComponent.class);
+        assertHasMethod(model, "com.artemis.E simpleComponentValue1(java.lang.Integer value1)");
+        assertHasMethod(model, "com.artemis.E simpleComponentValue2(java.lang.String value2)");
+        assertHasMethod(model, "java.lang.Integer simpleComponentValue1()");
+        assertHasMethod(model, "java.lang.String simpleComponentValue2()");
+    }
 }

--- a/artemis-fluid/artemis-fluid-core/src/test/java/com/artemis/generator/strategy/e/ComponentMethodProxyStrategyTest.java
+++ b/artemis-fluid/artemis-fluid-core/src/test/java/com/artemis/generator/strategy/e/ComponentMethodProxyStrategyTest.java
@@ -51,4 +51,15 @@ public class ComponentMethodProxyStrategyTest extends StrategyTest {
         assertHasMethod(model,"com.artemis.generator.strategy.e.Proof proofFluid(com.artemis.generator.strategy.e.Proof p0)");
     }
 
+    @Test
+    public void When_public_void_parameterized_method_is_defined_in_generic_base_class() {
+        TypeModel model = applyStrategy(ComponentMethodProxyStrategy.class, SimpleComponent.class);
+        assertHasMethod(model,"com.artemis.E simpleComponent(java.lang.Integer p0,java.lang.String p1,int p2)");
+    }
+
+    @Test
+    public void When_public_return_value_parameterized_method_is_defined_in_generic_base_class() {
+        TypeModel model = applyStrategy(ComponentMethodProxyStrategy.class, SimpleComponent.class);
+        assertHasMethod(model,"java.lang.Integer simpleComponentDummy(java.lang.Integer p0,java.lang.String p1,int p2)");
+    }
 }

--- a/artemis-fluid/artemis-fluid-core/src/test/java/com/artemis/generator/strategy/e/GenericComponents.java
+++ b/artemis-fluid/artemis-fluid-core/src/test/java/com/artemis/generator/strategy/e/GenericComponents.java
@@ -1,0 +1,27 @@
+package com.artemis.generator.strategy.e;
+
+import com.artemis.Component;
+
+abstract class SingleValueComponent<T> extends Component {
+    public T value;
+}
+
+final class StringComponent extends SingleValueComponent<String> { }
+
+abstract class BaseComponent<T1, T2> extends Component {
+    public T1 value1;
+    public T2 value2;
+
+    public void set(T1 a, T2 b, int c) {
+        value1 = a;
+        value2 = b;
+    }
+
+    public T1 dummy(T1 a, T2 b, int c) {
+        return value1;
+    }
+}
+
+abstract class SubComponent<T> extends BaseComponent<T, String> { }
+
+final class SimpleComponent extends SubComponent<Integer> { }


### PR DESCRIPTION
This PR adds support for components inheriting from generic base classes.
The most simple (and probably most important) use case are components with just a single value. In this case you often end up with several components that only differ in the type of the embedded value. With this PR we can now use generic types:
```java
abstract class SingleValueComponent<T> {
  public T value;
  public void set(T value) { this.value = value; }
}

// no more boilerplate code for simple components!
class TextureMeta extends SingleValueComponent<String> { } // used to only store the path to the asset
@Transient class TextureRef extends SingleValueComponent<Texture> { } // stores the actual asset
```
This works especially well with the artemis-odb-contrib AssetManager (and LibGDX):
```java
class SimpleAssetManager<A extends SingleValueComponent<String>, B extends SingleValueComponent<B>> extends AssetManager<A, B> {
    private final com.badlogic.gdx.assets.AssetManager assets;
    private final Class<B> refClass;
    
    public Manager(com.badlogic.gdx.assets.AssetManager assets, Class<A> classA, Class<B> classB) {
        super(classA, classB);
        this.assets = assets;
        refClass = classB;
    }
    
    @Override
    protected void setup(final int entity, final A a, final B b) {
        b.value = assets.get(a.value, refClass);
    }

    public static <A extends SingleValueComponent<String>, B extends SingleValueComponent<B>> Manager<A, B> create(com.badlogic.gdx.assets.AssetManager assets, Class<A> classA, Class<B> classB) {
        return new Manager<>(assets, classA, classB);
    }
}

// adding a new asset manager is now as simple as:
final WorldConfiguration cfg = new WorldConfigurationBuilder()
    .with(SimpleAssetManager.create(assets, TextureMeta.class, Texture.class))
    .with(SimpleAssetManager.create(assets, FontMeta.class, Font.class))
    // ...
    .build();
```

This also works with more complicated scenarios with various (generic) classes in between, although this might be an unusual use case, see the newly added tests.